### PR TITLE
Go back to manually specifying content for answer icons

### DIFF
--- a/_sass/_cim.scss
+++ b/_sass/_cim.scss
@@ -380,15 +380,24 @@ i.answer-icon {
     opacity: 0.75;
     z-index: 20;
     transform: translateY(-50%) translateX(-50%);
-    text-shadow: rgb(0, 0, 0) 1px 0px 0px, rgb(0, 0, 0) 0.540302px 0.841471px 0px, rgb(0, 0, 0) -0.416147px 0.909297px 0px, rgb(0, 0, 0) -0.989993px 0.14112px 0px, rgb(0, 0, 0) -0.653644px -0.756803px 0px, rgb(0, 0, 0) 0.283662px -0.958924px 0px, rgb(0, 0, 0) 0.96017px -0.279416px 0px;
 }
 
 
 i.answer-icon.correct {
     color: green;
+    &:before {
+        content: "\f00c";
+        -webkit-text-stroke-width: 2px;
+        -webkit-text-stroke-color: black;
+    }
 }
 i.answer-icon.incorrect {
     color: red;
+    &:before {
+        content: "\f00d";
+        -webkit-text-stroke-width: 2px;
+        -webkit-text-stroke-color: black;
+    }
 }
 
 div.flag-correct i.answer-icon.correct,

--- a/index.html
+++ b/index.html
@@ -189,8 +189,8 @@ This is a method for teaching absolute pitch to children aged 2-6. Children shou
             {%- for color in site.data.chords -%}
             <div class="flag-wrapper" id="{{ color.name }}-flag" data-color="{{ color.name}}">
                 <div class="flag {{ color.name }}" onclick="select_flag(this);">
-                    <i class="answer-icon correct fa fa-check"></i>
-                    <i class="answer-icon incorrect fa fa-times"></i>
+                    <i class="answer-icon correct fa"></i>
+                    <i class="answer-icon incorrect fa"></i>
                     <div class="chord-notes-container chord-{{color.chord | replace: "/", "-"}}">
                         {%- assign _notes = display_notes
                         | where_exp: "display", "display.first == color.name"


### PR DESCRIPTION
Ideally we'd have a CSS rule for "any :before applied to an `answer-icon`" that contains the `-webkit-text-stroke-width`, but repeating ourselves twice is not that big a deal.

Fixes #25.