### PR TITLE
Fix infobox heights

### DIFF
--- a/_sass/_cim.scss
+++ b/_sass/_cim.scss
@@ -442,8 +442,8 @@ body.colorscheme-light div.flag {
       width: 95vw; // Fallback
       width: 95dvw;
   }
-  height: 90vh;
-  height: 90dvh;
+  max-height: 90vh;
+  max-height: 90dvh;
   padding: 10px;
   overflow-y: auto;
   border: 1px solid #cccccc;


### PR DESCRIPTION
In a recent change we fixed the infobox height at a specific proportion of the viewport, but I realized that this makes the profile selector super long for no reason. This changes it over to using max-height instead of fixed height.