### PR TITLE
Fix issues with profile setting dialog

### DIFF
--- a/_sass/_cim.scss
+++ b/_sass/_cim.scss
@@ -560,8 +560,8 @@ body.colorscheme-dark .infobox {
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
-    width: 30vw; // Fallback
-    width: 30dvw;
+    width: 50vw; // Fallback
+    width: 50dvw;
     padding: 10px;
     border: 1px solid #cccccc;
     border-radius: 5px;

--- a/index.html
+++ b/index.html
@@ -315,7 +315,7 @@ This is a method for teaching absolute pitch to children aged 2-6. Children shou
         <input type="text" id="profile_name_setting" class="entry">
     </div>
     <div class="entry-row">
-        <label for="profile_icon_selector">Icon:</label>
+        <label for="profile_icon_selector">Icon:</label><br/>
 
         <input type="radio" name="profile_icon_selector"
                             value="fa-user" id="npis-user">
@@ -346,7 +346,7 @@ This is a method for teaching absolute pitch to children aged 2-6. Children shou
         <label for="npis-taxi"><i class="fa fa-solid fa-taxi"></i></label>
     </div>
     <div class="entry-row">
-        <label for="show_chord_name_mode">Show chord names:</label>
+        <label for="show_chord_name_mode">Show chord names:</label><br/>
         <select class="selector" name="show_chord_name_mode" id="show-chord-name-mode-selector">
             <option value="always">Always</option>
             <option value="black_only">Black chords only</option>


### PR DESCRIPTION
1. More gracefully handle the situation where we get into an illegal state where the profile ID corresponds to a deleted or otherwise non-existent profile.
2. Switch the profile adder / settings adjuster dialogue away from being an infobox, so now the only way to toggle it is with the X or one of the buttons.
3. Make it so that you fall back to the guest profile when a profile is deleted.
4. Various fixes related to visibility of the profile settings adder / adjuster in different scenarios.