### PR TITLE
Fix issue with perfect score colors

### DIFF
--- a/js/cim.js
+++ b/js/cim.js
@@ -452,6 +452,12 @@ function update_stats_display() {
         container_elem.classList.remove("done");
     }
 
+    if (correct == identifications) {
+        container_elem.classList.add("perfect");
+    } else {
+        container_elem.classList.remove("perfect");
+    }
+
     // Update single note stats
     const notes_correct = stats.notes.correct;
     const note_identifications = stats.notes.identifications;


### PR DESCRIPTION
When adding single note stats, we accidentally removed the "turn everything green on a perfect score" thing, this restores that.