### PR TITLE
Fix deprecations and bitrot

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Ruby
-        uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+        uses: ruby/setup-ruby@v1.205.0
         with:
           ruby-version: '3.2' # Not needed with a .ruby-version file
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/_sass/_cim.scss
+++ b/_sass/_cim.scss
@@ -1,3 +1,4 @@
+@use "sass:color";
 @import "variables";
 
 body {
@@ -643,11 +644,11 @@ div.pulldown-item {
 }
 
 body.colorscheme-dark div.pulldown-item:hover {
-    background-color: lighten($bg-color-dark, 12.5);
+    background-color: color.scale($bg-color-dark, $lightness: 12.5%);
 }
 
 body.colorscheme-light div.pulldown-item:hover {
-    background-color: darken($bg-color, 12.5);
+    background-color: color.scale($bg-color, $lightness: -12.5%);
 }
 
 div.pulldown-item > i.profile-settings-icon,


### PR DESCRIPTION
1. Upgrades `setup-ruby`:
    The older version is either incompatible with the newer Ubuntu runners or it just thinks it is.

     See https://github.com/ruby/setup-ruby/issues/595
2. `darken` is deprecated, so fix that.