### PR TITLE
Fix display of Bb and Eb note shapes

### DIFF
--- a/_includes/_note_shapes.scss
+++ b/_includes/_note_shapes.scss
@@ -60,7 +60,7 @@ div.use-shapes {
         clip-path: $rounded_square;
     }
 
-    div.note-wrapper.note-Bb3 {
+    div.note-wrapper.note-B-flat3 {
         div.note {
             clip-path: $trapezoid;
         }
@@ -70,7 +70,7 @@ div.use-shapes {
         }
     }
 
-    div.note-wrapper.note-Bb4 {
+    div.note-wrapper.note-B-flat4 {
         div.note {
             clip-path: $trapezoid_u;
         }
@@ -144,7 +144,7 @@ div.use-shapes {
         }
     }
 
-    div.note-wrapper.note-Eb4 {
+    div.note-wrapper.note-E-flat4 {
         div.note {
             clip-path: $teardrop;
         }

--- a/index.html
+++ b/index.html
@@ -182,7 +182,8 @@ This is a method for teaching absolute pitch to children aged 2-6. Children shou
                         | first | last -%}
                         {%- for note in _notes -%}
                         {%- assign absolute_note = color.notes[forloop.index0]
-                                                   | replace: "#", "-sharp" -%}
+                                                   | replace: "#", "-sharp"
+                                                   | replace: "b", "-flat" -%}
                         {%- assign note_class = note
                                                 | replace: "#", "-sharp"
                                                 | replace: "b", "-flat"


### PR DESCRIPTION
The wrong CSS class was used for these notes, making them show up as circles when shape mode is used. I think this fixes it, but I'm not 100% sure how to locally build and test.