### PR TITLE
Update makefile to automatically init when necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,17 +9,19 @@ help:
 	@echo 'make html          Generate the web site'
 	@echo 'make clean         Clean up generated site'
 
-.PHONY: init
-init:
+vendor/bundle:
 	bundle config set --local path 'vendor/bundle'
 	bundle install
 
+.PHONY: init
+init: vendor/bundle
+
 .PHONY: html
-html:
+html: vendor/bundle
 	$(JEKYLL) build
 
 .PHONY: serve
-serve:
+serve: vendor/bundle
 	$(JEKYLL) serve -w
 
 .PHONY: clean


### PR DESCRIPTION
Previously it would  just complain if you tried `make html` or `make serve` without `make init`.