### PR TITLE
Add option to persist cat reaction face

### DIFF
--- a/index.html
+++ b/index.html
@@ -403,6 +403,10 @@ This is a method for teaching absolute pitch to children aged 2-6. Children shou
         </select>
     </div>
     <div class="entry-row">
+        <label for="persist_reaction_face_setting">Persist Reaction Face:</label>
+        <input type="checkbox" id="persist_reaction_face_setting" class="entry">
+    </div>
+    <div class="entry-row">
         <label for="target_number_setting">Target Number:</label>
         <input type="number" id="target_number_setting" class="entry">
     </div>


### PR DESCRIPTION
Some younger children especially may have trouble understanding why the cat is still sad even when they get one right, so this adds an option to persist the reaction face from their last reaction, that way "keep the cat happy" is equivalent to "keep getting it right".

After the child has finished their target identifications, the old behavior is restored.

CC @mahmoud