### PR TITLE
Add base64 to gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gem "jekyll", "~> 4"
 
 gem "json", "~> 2.7"
 gem 'csv', '~> 3.0'
+gem 'base64'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.3.0)
     bigdecimal (3.1.8)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)
@@ -70,6 +71,7 @@ PLATFORMS
   x86_64-linux-gnu
 
 DEPENDENCIES
+  base64
   csv (~> 3.0)
   jekyll (~> 4)
   json (~> 2.7)


### PR DESCRIPTION
base64 is apparently not in the standard library of Ruby or whatever now.