### PR TITLE
Fix stats modal scroll and add single note stats

### DIFF
--- a/_sass/_cim.scss
+++ b/_sass/_cim.scss
@@ -753,29 +753,25 @@ a.download-button.visible {
 
 // Stats container
 div.stats-history-container {
-    width: fit-content;
+    width: max-content;
     max-height: 40vh; // Fallback
     max-height: 40dvh;
-    max-width: 95vw; // Fallback
-    max-width: 95dvw;
+    max-width: 100vw; // Fallback
+    max-width: 100dvw;
     overflow-y: auto;
-    flex-flow: column nowrap;
-    align-content: flex-start;
-    overflow-x: none;
+    overflow-x: auto;
 }
 
 div.stats-history-container.visible {
-    display: inline-flex;
+    display: grid;
+    grid-template-columns: repeat(4, max-content);
+    align-items: center;
+    column-gap: 2rem;
+    row-gap: 0.75rem;
 }
 
 div.stats-history-container > div.stats-history-item {
-    display: inline-flex;
-    width: fit-content;
-    white-space: nowrap;
-    flex-flow: row nowrap;
-    max-height: 4rem;
-    margin-top: 0.5rem;
-    margin-bottom: 0.5rem;
+    display: contents;
 }
 
 body.colorscheme-dark div.stats-history-container > div.stats-history-item > div.stats-color {
@@ -787,19 +783,15 @@ body.colorscheme-light div.stats-history-container > div.stats-history-item > di
 }
 
 div.stats-history-item > div.stats-color {
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
-    flex: 0 0 10%;
-    width: 10%;
+    align-self: stretch;
+    min-width: 4dvw;
 }
 
 div.stats-history-item > div.stats-date {
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
-    flex: 0 0 20%;
+    white-space: nowrap;
     @media only screen and (max-width: 1080px) {
         font-size: 0.8em;
     }
@@ -807,12 +799,21 @@ div.stats-history-item > div.stats-date {
 
 div.stats-history-item > div.session-stats {
     display: flex;
+    flex-direction: column;
     justify-content: center;
-    align-items: center;
-    margin-left: 0.5rem;
-    margin-right: 0.5rem;
     font-weight: bold;
-    min-width: 20vw;
+    line-height: 1.3;
+    white-space: nowrap;
+}
+
+div.stats-history-item > div.session-stats > div.sn-session-stats {
+    font-size: 0.8em;
+    opacity: 0.8;
+}
+
+div.stats-history-item > div.session-emoji {
+    display: flex;
+    align-items: center;
 }
 
 .stats-container .close-button {

--- a/js/cim.js
+++ b/js/cim.js
@@ -1132,10 +1132,30 @@ function populate_stats_history_modal() {
 
         let stats = document.createElement("div");
         stats.classList.add("session-stats");
-        stats.innerText = correct + " / " + identifications + " (" +
-            percentage.toFixed(1) +
-            "%) " + emoji;
+
+        let chord_stats_text = document.createElement("div");
+        chord_stats_text.innerText = correct + " / " + identifications + " (" +
+            percentage.toFixed(1) + "%)";
+        stats.appendChild(chord_stats_text);
+
+        if (session.notes && session.notes.identifications > 0) {
+            const notes_correct = session.notes.correct;
+            const notes_identifications = session.notes.identifications;
+            const notes_percentage = calculate_percentage(notes_correct, notes_identifications);
+
+            let note_stats = document.createElement("div");
+            note_stats.classList.add("sn-session-stats");
+            note_stats.innerText = "♪ " + notes_correct + " / " + notes_identifications +
+                " (" + notes_percentage.toFixed(1) + "%)";
+            stats.appendChild(note_stats);
+        }
+
         div.appendChild(stats);
+
+        let emoji_elem = document.createElement("div");
+        emoji_elem.classList.add("session-emoji");
+        emoji_elem.innerText = emoji;
+        div.appendChild(emoji_elem);
 
         stats_container.appendChild(div);
     }


### PR DESCRIPTION
The stats modal always had an annoying property where the rows were a bit bigger than the modal itself. When adding single notes this became a bigger problem, so I ended up fixing them together rather than one at a time.