### PR TITLE
Add state import and merge support

### DIFF
--- a/_sass/_cim.scss
+++ b/_sass/_cim.scss
@@ -751,6 +751,67 @@ a.download-button.visible {
     display: block;
 }
 
+.import-state-container {
+    max-height: 90vh;
+    max-height: 90dvh;
+    overflow-y: auto;
+
+    @media only screen and (max-width: 700px) {
+        width: 90vw;
+        width: 90dvw;
+    }
+}
+
+.import-state-container button {
+    display: inline-block;
+}
+
+.import-state-container .close-button {
+    border: 0;
+    padding: 0;
+    color: inherit;
+    background: transparent;
+    cursor: pointer;
+}
+
+.import-state-container h2 {
+    padding-right: 2.5rem;
+}
+
+.import-settings-grid {
+    display: grid;
+    grid-template-columns: minmax(7rem, 1fr) minmax(9rem, 2fr) minmax(9rem, 2fr);
+    gap: 0.5rem 1rem;
+    align-items: center;
+
+    @media only screen and (max-width: 700px) {
+        grid-template-columns: minmax(6rem, 1fr) minmax(7rem, 2fr) minmax(7rem, 2fr);
+        gap: 0.4rem;
+        font-size: 0.85em;
+    }
+}
+
+.import-settings-grid .import-setting-heading {
+    font-weight: bold;
+    text-align: center;
+}
+
+.import-settings-grid .import-setting-value {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+    overflow-wrap: anywhere;
+}
+
+.import-all-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: space-between;
+    align-items: center;
+    margin: 1rem 0;
+}
+
 // Stats container
 div.stats-history-container {
     width: max-content;

--- a/_sass/_cim.scss
+++ b/_sass/_cim.scss
@@ -748,18 +748,23 @@ a.download-button {
 }
 
 a.download-button.visible {
-    display: block;
+    display: inline-flex;
+}
+
+.transfer-button-container {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 0.5rem;
 }
 
 .import-state-container {
+    box-sizing: border-box;
+    width: min(98vw, 80rem);
+    width: min(98dvw, 80rem);
     max-height: 90vh;
     max-height: 90dvh;
+    padding: 1.5rem;
     overflow-y: auto;
-
-    @media only screen and (max-width: 700px) {
-        width: 90vw;
-        width: 90dvw;
-    }
 }
 
 .import-state-container button {
@@ -775,20 +780,196 @@ a.download-button.visible {
 }
 
 .import-state-container h2 {
+    margin: 0 0 0.5rem;
     padding-right: 2.5rem;
+    text-align: center;
+}
+
+.import-file-description,
+.import-followup-description,
+.import-merge-description {
+    text-align: center;
+}
+
+.import-file-description {
+    margin: 0.25rem 0;
+    font-size: 0.85em;
+    opacity: 0.75;
+}
+
+.import-followup-description {
+    margin: 0.75rem auto 1rem;
+    line-height: 1.5;
+}
+
+.import-profile-comparison {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+    margin: 1rem 0;
+
+    @media only screen and (max-width: 650px) {
+        grid-template-columns: 1fr;
+    }
+}
+
+.import-profile-card {
+    padding: 1rem;
+    border: 1px solid currentColor;
+    border-radius: 0.5rem;
+    background: rgba(127, 127, 127, 0.08);
+}
+
+.import-profile-card.imported {
+    border-width: 2px;
+}
+
+.import-profile-card h3 {
+    margin: 0 0 0.75rem;
+    text-align: center;
+}
+
+.import-profile-identity {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 1rem;
+    font-size: 1.35em;
+    font-weight: bold;
+}
+
+.import-profile-identity .fa {
+    min-width: 1.25em;
+    text-align: center;
+}
+
+.import-profile-detail {
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    gap: 0.35rem 0.75rem;
+    margin: 0.35rem 0;
+}
+
+.import-profile-detail dt {
+    font-weight: bold;
+}
+
+.import-profile-detail dd {
+    margin: 0;
+}
+
+.import-history-endpoints {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    align-items: center;
+}
+
+.import-color-dot {
+    display: inline-block;
+    width: 0.85rem;
+    height: 0.85rem;
+    border: 1px solid currentColor;
+    border-radius: 0.2rem;
+    vertical-align: -0.05rem;
+}
+
+.import-table-wrapper {
+    max-width: 100%;
+    margin: 1rem 0;
+    overflow-x: auto;
+}
+
+.import-profile-table {
+    width: 100%;
+    min-width: 54rem;
+    border-collapse: collapse;
+    font-size: 0.82em;
+}
+
+.import-profile-table th,
+.import-profile-table td {
+    padding: 0.55rem;
+    border: 1px solid rgba(127, 127, 127, 0.45);
+    text-align: center;
+}
+
+.import-profile-table td {
+    white-space: nowrap;
+}
+
+.import-profile-table tbody th {
+    text-align: left;
+}
+
+.import-table-profile-name {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.import-table-conflicts {
+    display: block;
+    margin-top: 0.2rem;
+    font-size: 0.75em;
+    font-weight: normal;
+    opacity: 0.75;
+}
+
+.import-select-all-row th {
+    text-align: right;
+}
+
+.import-button-container {
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.import-state-container .import-button {
+    min-width: 7rem;
+    min-height: 2.5rem;
+    padding: 0.55rem 1rem;
+    border: 1px solid rgba(127, 127, 127, 0.8);
+    border-radius: 0.35rem;
+    color: inherit;
+    background: rgba(127, 127, 127, 0.18);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+    font: inherit;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.import-state-container .import-button:hover:not(:disabled) {
+    background: rgba(127, 127, 127, 0.3);
+}
+
+.import-state-container .import-button:active:not(:disabled) {
+    box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+
+.import-state-container .import-button.primary {
+    border-color: $link-color-dark;
+}
+
+.import-state-container .import-button.subtle {
+    min-width: 0;
+    min-height: 2rem;
+    padding: 0.35rem 0.75rem;
+    font-size: 0.85em;
+}
+
+.import-state-container .import-button:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
 }
 
 .import-settings-grid {
     display: grid;
-    grid-template-columns: minmax(7rem, 1fr) minmax(9rem, 2fr) minmax(9rem, 2fr);
+    grid-template-columns: max-content minmax(12rem, 1fr) minmax(12rem, 1fr);
     gap: 0.5rem 1rem;
     align-items: center;
-
-    @media only screen and (max-width: 700px) {
-        grid-template-columns: minmax(6rem, 1fr) minmax(7rem, 2fr) minmax(7rem, 2fr);
-        gap: 0.4rem;
-        font-size: 0.85em;
-    }
+    min-width: 34rem;
 }
 
 .import-settings-grid .import-setting-heading {
@@ -796,11 +977,26 @@ a.download-button.visible {
     text-align: center;
 }
 
+.import-settings-grid .import-setting-name {
+    font-weight: 600;
+    white-space: nowrap;
+}
+
 .import-settings-grid .import-setting-value {
-    display: flex;
+    display: grid;
+    grid-template-columns: auto 1fr;
     gap: 0.4rem;
     align-items: center;
+}
+
+.import-settings-grid .import-setting-value-text {
+    min-width: 0;
+    text-align: center;
     overflow-wrap: anywhere;
+}
+
+.import-settings-grid .import-setting-icon {
+    font-size: 1.4em;
 }
 
 .import-all-controls {
@@ -810,6 +1006,25 @@ a.download-button.visible {
     justify-content: space-between;
     align-items: center;
     margin: 1rem 0;
+}
+
+@media only screen and (max-width: 650px) {
+    .import-state-container {
+        width: 96vw;
+        width: 96dvw;
+        padding: 1rem;
+    }
+
+    .import-settings-grid {
+        grid-template-columns: max-content minmax(9rem, 1fr) minmax(9rem, 1fr);
+        min-width: 28rem;
+        gap: 0.4rem 0.6rem;
+        font-size: 0.9em;
+    }
+
+    #import-conflict-step {
+        overflow-x: auto;
+    }
 }
 
 // Stats container

--- a/e2e/import-export.spec.js
+++ b/e2e/import-export.spec.js
@@ -1,0 +1,240 @@
+import { test, expect, goto_app } from "./fixtures/audio.js";
+
+async function unlock_import_export(page) {
+    await page.locator("img.logo").click({ clickCount: 6 });
+    await expect(page.locator("#download-link")).toHaveClass(/visible/);
+    await expect(page.locator("#upload-link")).toHaveClass(/visible/);
+}
+
+async function upload_backup(page, backup, name = "backup.json") {
+    await page.locator("#import-file-input").setInputFiles({
+        name,
+        mimeType: "application/json",
+        buffer: Buffer.from(JSON.stringify(backup)),
+    });
+    await expect(page.locator("#import-state-container")).toHaveClass(/visible/);
+}
+
+async function stored_data(page) {
+    return page.evaluate(() => ({
+        state: JSON.parse(localStorage.getItem("cim_state")),
+        history: JSON.parse(localStorage.getItem("cim_session_history")),
+    }));
+}
+
+function copied_profile(profile, { id, name, target_number, settings_updated_time }) {
+    return {
+        ...structuredClone(profile),
+        id,
+        name,
+        target_number,
+        settings_updated_time,
+    };
+}
+
+test.describe("Import and export easter egg", () => {
+    test("reveals import and export together and cancel leaves data unchanged", async ({ page }) => {
+        await goto_app(page);
+        await expect(page.locator("#download-link")).not.toHaveClass(/visible/);
+        await expect(page.locator("#upload-link")).not.toHaveClass(/visible/);
+        await unlock_import_export(page);
+
+        const before = await stored_data(page);
+        await upload_backup(page, {
+            format_version: 1,
+            exported_at: 100,
+            state: before.state,
+            history: before.history,
+        });
+        await page.locator("#cancel-import-button").click();
+
+        await expect(page.locator("#import-state-container")).not.toHaveClass(/visible/);
+        expect(await stored_data(page)).toEqual(before);
+    });
+
+    test("rejects invalid backup files without changing data", async ({ page }) => {
+        await goto_app(page);
+        await unlock_import_export(page);
+        const before = await stored_data(page);
+        const dialog = page.waitForEvent("dialog");
+
+        await page.locator("#import-file-input").setInputFiles({
+            name: "not-a-backup.json",
+            mimeType: "application/json",
+            buffer: Buffer.from('{"hello":"world"}'),
+        });
+        const alert = await dialog;
+        expect(alert.message()).toContain("not a CIM backup");
+        await alert.dismiss();
+
+        await expect(page.locator("#import-state-container")).not.toHaveClass(/visible/);
+        expect(await stored_data(page)).toEqual(before);
+    });
+
+    test("replace installs the imported state and history", async ({ page }) => {
+        await goto_app(page);
+        await unlock_import_export(page);
+        const before = await stored_data(page);
+        const imported_state = structuredClone(before.state);
+        imported_state.profiles["100"].target_number = 41;
+        const imported_history = {
+            100: {
+                yellow: [{
+                    start_time: 10,
+                    updated_time: 11,
+                    identifications: 3,
+                    current_chord: "yellow",
+                    done: true,
+                }],
+            },
+        };
+
+        await upload_backup(page, {
+            format_version: 1,
+            exported_at: 200,
+            state: imported_state,
+            history: imported_history,
+        });
+        await page.locator("#replace-import-button").click();
+        await expect(page.locator("#play-button")).not.toHaveClass(/deactivated/);
+
+        const after = await stored_data(page);
+        expect(after.state.profiles["100"].target_number).toBe(41);
+        expect(after.history["100"].yellow.some(
+            (session) => session.start_time === 10)).toBe(true);
+    });
+
+    test("merge adds users and combines session history without a settings prompt",
+               async ({ page }) => {
+        await goto_app(page);
+        await unlock_import_export(page);
+        const before = await stored_data(page);
+        const imported_profile = copied_profile(before.state.profiles["100"], {
+            id: 101,
+            name: "Imported",
+            target_number: 30,
+            settings_updated_time: 200,
+        });
+        const imported_state = structuredClone(before.state);
+        imported_state.profiles = {
+            100: before.state.profiles["100"],
+            101: imported_profile,
+        };
+        imported_state.current_profile = 101;
+
+        await upload_backup(page, {
+            format_version: 1,
+            exported_at: 200,
+            state: imported_state,
+            history: {
+                101: {
+                    yellow: [{
+                        start_time: 20,
+                        updated_time: 21,
+                        identifications: 4,
+                        current_chord: "yellow",
+                        done: true,
+                    }],
+                },
+            },
+        });
+        await page.locator("#merge-import-button").click();
+        await expect(page.locator("#play-button")).not.toHaveClass(/deactivated/);
+
+        const after = await stored_data(page);
+        expect(after.state.profiles["100"].name).toBe("Guest");
+        expect(after.state.profiles["101"].name).toBe("Imported");
+        expect(after.history["101"].yellow).toHaveLength(1);
+    });
+
+    test("merge resolves settings once per user and can apply an age choice to all",
+               async ({ page }) => {
+        await goto_app(page);
+        const initial = await stored_data(page);
+        const guest = initial.state.profiles["100"];
+        const local_profiles = {
+            100: guest,
+            101: copied_profile(guest, {
+                id: 101,
+                name: "Alpha",
+                target_number: 25,
+                settings_updated_time: 100,
+            }),
+            102: copied_profile(guest, {
+                id: 102,
+                name: "Beta",
+                target_number: 30,
+                settings_updated_time: 100,
+            }),
+            103: copied_profile(guest, {
+                id: 103,
+                name: "Gamma",
+                target_number: 35,
+                settings_updated_time: 300,
+            }),
+        };
+        await page.evaluate((profiles) => {
+            const state = JSON.parse(localStorage.getItem("cim_state"));
+            state.profiles = profiles;
+            localStorage.setItem("cim_state", JSON.stringify(state));
+        }, local_profiles);
+        await page.reload();
+        await expect(page.locator("#play-button")).not.toHaveClass(/deactivated/);
+        await unlock_import_export(page);
+
+        const imported_profiles = {
+            101: copied_profile(local_profiles["101"], {
+                id: 101,
+                name: "Alpha",
+                target_number: 40,
+                settings_updated_time: 200,
+            }),
+            102: copied_profile(local_profiles["102"], {
+                id: 102,
+                name: "Beta",
+                target_number: 50,
+                settings_updated_time: 200,
+            }),
+            103: copied_profile(local_profiles["103"], {
+                id: 103,
+                name: "Gamma",
+                target_number: 60,
+                settings_updated_time: 200,
+            }),
+        };
+        const imported_state = structuredClone(initial.state);
+        imported_state.profiles = {
+            100: initial.state.profiles["100"],
+            ...imported_profiles,
+        };
+
+        await upload_backup(page, {
+            format_version: 1,
+            exported_at: 200,
+            state: imported_state,
+            history: {},
+        });
+        await page.locator("#merge-import-button").click();
+
+        await expect(page.locator("#import-conflict-title")).toHaveText("Settings for Alpha");
+        await page.locator("#all-from-newer-button").click();
+        await page.locator("input[name='import-setting-target_number'][value='local']").check();
+        await page.locator("#next-import-conflict-button").click();
+
+        await expect(page.locator("#import-conflict-title")).toHaveText("Settings for Beta");
+        await page.locator("#apply-import-choice-to-all").check();
+        await page.locator("#all-from-older-button").click();
+        await page.locator("#next-import-conflict-button").click();
+
+        await expect(page.locator("#import-conflict-title")).toHaveText("Settings for Gamma");
+        await expect(page.locator(
+            "input[name='import-setting-target_number'][value='imported']")).toBeChecked();
+        await page.locator("#next-import-conflict-button").click();
+        await expect(page.locator("#play-button")).not.toHaveClass(/deactivated/);
+
+        const after = await stored_data(page);
+        expect(after.state.profiles["101"].target_number).toBe(25);
+        expect(after.state.profiles["102"].target_number).toBe(30);
+        expect(after.state.profiles["103"].target_number).toBe(60);
+    });
+});

--- a/e2e/import-export.spec.js
+++ b/e2e/import-export.spec.js
@@ -22,132 +22,291 @@ async function stored_data(page) {
     }));
 }
 
-function copied_profile(profile, { id, name, target_number, settings_updated_time }) {
+function copied_profile(profile, {
+    id,
+    name,
+    target_number,
+    settings_updated_time,
+    icon = profile.icon,
+}) {
     return {
         ...structuredClone(profile),
         id,
         name,
+        icon,
         target_number,
         settings_updated_time,
     };
 }
 
+function session(start_time, current_chord = "yellow") {
+    return {
+        start_time,
+        updated_time: start_time + 60,
+        identifications: 3,
+        correct: 3,
+        confusion_matrix: {},
+        current_chord,
+        done: true,
+    };
+}
+
+async function set_local_profiles(page, profiles, state_updates = {}) {
+    await page.evaluate(({ profiles, state_updates }) => {
+        const state = JSON.parse(localStorage.getItem("cim_state"));
+        Object.assign(state, state_updates);
+        state.profiles = profiles;
+        localStorage.setItem("cim_state", JSON.stringify(state));
+    }, { profiles, state_updates });
+    await page.reload();
+    await expect(page.locator("#play-button")).not.toHaveClass(/deactivated/);
+}
+
+async function open_guest_import_conflict(page, {
+    exported_at,
+    imported_stats_updated_time,
+    history = {},
+    filename = "backup.json",
+}) {
+    await goto_app(page);
+    const before = await stored_data(page);
+    const local_profile = structuredClone(before.state.profiles["100"]);
+    local_profile.settings_updated_time = 300;
+    await set_local_profiles(page, { 100: local_profile });
+    await unlock_import_export(page);
+
+    const imported_profile = structuredClone(local_profile);
+    imported_profile.target_number = 40;
+    delete imported_profile.settings_updated_time;
+    if (imported_stats_updated_time === undefined) {
+        delete imported_profile.stats.updated_time;
+    } else {
+        imported_profile.stats.updated_time = imported_stats_updated_time;
+    }
+    const imported_state = structuredClone(before.state);
+    imported_state.profiles = { 100: imported_profile };
+    const backup = { state: imported_state, history };
+    if (exported_at !== undefined) {
+        backup.exported_at = exported_at;
+    }
+
+    await upload_backup(page, backup, filename);
+    await page.locator("#merge-import-button").click();
+    await expect(page.locator("#import-conflict-title")).toContainText("Guest");
+}
+
 test.describe("Import and export easter egg", () => {
-    test("reveals import and export together and cancel leaves data unchanged", async ({ page }) => {
+    test.use({ timezoneId: "America/New_York" });
+
+    test("reveals side-by-side import and export controls", async ({ page }) => {
         await goto_app(page);
         await expect(page.locator("#download-link")).not.toHaveClass(/visible/);
         await expect(page.locator("#upload-link")).not.toHaveClass(/visible/);
         await unlock_import_export(page);
 
+        const [download_box, upload_box] = await Promise.all([
+            page.locator("#download-link").boundingBox(),
+            page.locator("#upload-link").boundingBox(),
+        ]);
+        expect(Math.abs(download_box.y - upload_box.y)).toBeLessThan(2);
+        expect(upload_box.x).toBeGreaterThan(download_box.x + download_box.width);
+    });
+
+    test("cancel leaves data unchanged", async ({ page }) => {
+        await goto_app(page);
+        await unlock_import_export(page);
         const before = await stored_data(page);
+        const imported_state = structuredClone(before.state);
+        imported_state.profiles["100"].current_chord = "black";
+
         await upload_backup(page, {
             format_version: 1,
             exported_at: 100,
-            state: before.state,
+            state: imported_state,
             history: before.history,
         });
+        await expect(page.locator("#import-single-profile")).toBeVisible();
         await page.locator("#cancel-import-button").click();
 
         await expect(page.locator("#import-state-container")).not.toHaveClass(/visible/);
         expect(await stored_data(page)).toEqual(before);
     });
 
-    test("rejects invalid backup files without changing data", async ({ page }) => {
+    test("reports the profile and field for invalid backup values", async ({ page }) => {
         await goto_app(page);
         await unlock_import_export(page);
         const before = await stored_data(page);
+        const invalid_state = structuredClone(before.state);
+        invalid_state.profiles["100"].target_number = "lots";
         const dialog = page.waitForEvent("dialog");
 
         await page.locator("#import-file-input").setInputFiles({
-            name: "not-a-backup.json",
+            name: "invalid-profile.json",
             mimeType: "application/json",
-            buffer: Buffer.from('{"hello":"world"}'),
+            buffer: Buffer.from(JSON.stringify({ state: invalid_state, history: {} })),
         });
         const alert = await dialog;
-        expect(alert.message()).toContain("not a CIM backup");
+        expect(alert.message()).toContain(
+            'Profile "Guest" (ID 100): `target_number` must be a positive integer; got "lots".');
         await alert.dismiss();
 
         await expect(page.locator("#import-state-container")).not.toHaveClass(/visible/);
         expect(await stored_data(page)).toEqual(before);
     });
 
-    test("replace installs the imported state and history", async ({ page }) => {
+    test("migrates profiles from backups made before settings were added", async ({ page }) => {
+        await goto_app(page);
+        await unlock_import_export(page);
+        const before = await stored_data(page);
+        const legacy_profile = structuredClone(before.state.profiles["100"]);
+        legacy_profile.current_chord = "black";
+        for (const field of [
+            "target_number",
+            "current_instrument",
+            "show_chord_mode",
+            "reveal_chord_mode",
+            "chord_display_mode",
+            "single_note_mode",
+            "single_note_correctness_mode",
+            "persist_reaction_face",
+        ]) {
+            delete legacy_profile[field];
+        }
+        const legacy_state = {
+            profiles: { 100: legacy_profile },
+            current_profile: 100,
+            current_chord: "black",
+        };
+
+        await upload_backup(page, {
+            state: legacy_state,
+            history: { 100: { black: [session(1690504698, "black")] } },
+        }, "cim_state_1690723363.json");
+        await expect(page.locator("#import-single-profile")).toBeVisible();
+        await expect(page.locator("#incoming-profile-summary")).toContainText("2023-07-27");
+        await page.locator("#replace-import-button").click();
+        await expect(page.locator("#play-button")).not.toHaveClass(/deactivated/);
+
+        const imported = (await stored_data(page)).state.profiles["100"];
+        expect(imported.target_number).toBe(25);
+        expect(imported.current_instrument).toBe("piano_1");
+        expect(imported.single_note_mode).toBe("white_only_on_black");
+        expect(imported.persist_reaction_face).toBe(false);
+    });
+
+    test("uses exported_at instead of newer timestamps within the backup",
+               async ({ page }) => {
+        await open_guest_import_conflict(page, {
+            exported_at: 200,
+            imported_stats_updated_time: 400,
+        });
+
+        await expect(page.locator(
+            "input[name='import-setting-target_number'][value='local']")).toBeChecked();
+    });
+
+    test("derives the backup age from its newest data timestamp",
+               async ({ page }) => {
+        await open_guest_import_conflict(page, {
+            imported_stats_updated_time: 200,
+            history: { 100: { black: [session(400, "black")] } },
+            filename: "cim_state_1.json",
+        });
+
+        await expect(page.locator(
+            "input[name='import-setting-target_number'][value='imported']")).toBeChecked();
+    });
+
+    test("treats a backup without timestamps as old regardless of its filename",
+               async ({ page }) => {
+        await open_guest_import_conflict(page, {
+            filename: "cim_state_9999999999.json",
+        });
+
+        await expect(page.locator(
+            "input[name='import-setting-target_number'][value='local']")).toBeChecked();
+    });
+
+    test("single-profile preview explains and performs replacement", async ({ page }) => {
         await goto_app(page);
         await unlock_import_export(page);
         const before = await stored_data(page);
         const imported_state = structuredClone(before.state);
         imported_state.profiles["100"].target_number = 41;
+        imported_state.profiles["100"].current_chord = "black";
         const imported_history = {
-            100: {
-                yellow: [{
-                    start_time: 10,
-                    updated_time: 11,
-                    identifications: 3,
-                    current_chord: "yellow",
-                    done: true,
-                }],
-            },
+            100: { yellow: [session(1700000000)] },
         };
 
         await upload_backup(page, {
             format_version: 1,
-            exported_at: 200,
+            exported_at: 1700000200,
             state: imported_state,
             history: imported_history,
         });
+        await expect(page.locator("#existing-profile-card")).toContainText("Guest");
+        await expect(page.locator("#incoming-profile-card")).toContainText("1");
+        await expect(page.locator("#single-profile-merge-description")).toContainText(
+            "settings choice screen");
         await page.locator("#replace-import-button").click();
         await expect(page.locator("#play-button")).not.toHaveClass(/deactivated/);
 
         const after = await stored_data(page);
         expect(after.state.profiles["100"].target_number).toBe(41);
         expect(after.history["100"].yellow.some(
-            (session) => session.start_time === 10)).toBe(true);
+            (item) => item.start_time === 1700000000)).toBe(true);
     });
 
-    test("merge adds users and combines session history without a settings prompt",
+    test("multi-profile preview requires an action per user and supports bulk controls",
                async ({ page }) => {
         await goto_app(page);
         await unlock_import_export(page);
         const before = await stored_data(page);
-        const imported_profile = copied_profile(before.state.profiles["100"], {
+        const imported_state = structuredClone(before.state);
+        const guest = imported_state.profiles["100"];
+        guest.current_chord = "black";
+        imported_state.profiles["101"] = copied_profile(guest, {
             id: 101,
             name: "Imported",
             target_number: 30,
             settings_updated_time: 200,
         });
-        const imported_state = structuredClone(before.state);
-        imported_state.profiles = {
-            100: before.state.profiles["100"],
-            101: imported_profile,
+        const imported_history = {
+            100: { yellow: [session(1700000000)] },
+            101: { black: [session(1700100000, "black"), session(1700200000, "black")] },
         };
-        imported_state.current_profile = 101;
 
         await upload_backup(page, {
             format_version: 1,
-            exported_at: 200,
+            exported_at: 1700200100,
             state: imported_state,
-            history: {
-                101: {
-                    yellow: [{
-                        start_time: 20,
-                        updated_time: 21,
-                        identifications: 4,
-                        current_chord: "yellow",
-                        done: true,
-                    }],
-                },
-            },
+            history: imported_history,
         });
-        await page.locator("#merge-import-button").click();
+        const rows = page.locator("#import-profile-table-body tr");
+        await expect(rows).toHaveCount(2);
+        await expect(rows.nth(1)).toContainText("2");
+        await expect(page.locator("#continue-import-button")).toBeDisabled();
+
+        await page.getByLabel("Merge all").check();
+        await expect(page.getByLabel("Merge Guest")).toBeChecked();
+        await expect(page.getByLabel("Merge Imported")).toBeChecked();
+        await expect(page.locator("#continue-import-button")).toBeEnabled();
+        await page.locator("#clear-import-selections-button").click();
+        await expect(page.locator("#continue-import-button")).toBeDisabled();
+
+        await page.getByLabel("Don't import Guest").check();
+        await page.getByLabel("Replace Imported").check();
+        await page.locator("#continue-import-button").click();
         await expect(page.locator("#play-button")).not.toHaveClass(/deactivated/);
 
         const after = await stored_data(page);
-        expect(after.state.profiles["100"].name).toBe("Guest");
         expect(after.state.profiles["101"].name).toBe("Imported");
-        expect(after.history["101"].yellow).toHaveLength(1);
+        expect(after.history["101"].black).toHaveLength(2);
+        expect(after.history["100"]?.yellow?.some(
+            (item) => item.start_time === 1700000000) || false).toBe(false);
     });
 
-    test("merge resolves settings once per user and can apply an age choice to all",
+    test("merge shows only differing settings and handles global settings separately",
                async ({ page }) => {
         await goto_app(page);
         const initial = await stored_data(page);
@@ -173,16 +332,14 @@ test.describe("Import and export easter egg", () => {
                 settings_updated_time: 300,
             }),
         };
-        await page.evaluate((profiles) => {
-            const state = JSON.parse(localStorage.getItem("cim_state"));
-            state.profiles = profiles;
-            localStorage.setItem("cim_state", JSON.stringify(state));
-        }, local_profiles);
-        await page.reload();
-        await expect(page.locator("#play-button")).not.toHaveClass(/deactivated/);
+        await set_local_profiles(page, local_profiles, {
+            suppress_changelog_notifications: true,
+            changelog_last_read_date: "9999-12-31",
+        });
         await unlock_import_export(page);
 
         const imported_profiles = {
+            100: initial.state.profiles["100"],
             101: copied_profile(local_profiles["101"], {
                 id: 101,
                 name: "Alpha",
@@ -194,6 +351,7 @@ test.describe("Import and export easter egg", () => {
                 name: "Beta",
                 target_number: 50,
                 settings_updated_time: 200,
+                icon: "fa-taxi",
             }),
             103: copied_profile(local_profiles["103"], {
                 id: 103,
@@ -203,10 +361,9 @@ test.describe("Import and export easter egg", () => {
             }),
         };
         const imported_state = structuredClone(initial.state);
-        imported_state.profiles = {
-            100: initial.state.profiles["100"],
-            ...imported_profiles,
-        };
+        imported_state.profiles = imported_profiles;
+        imported_state.suppress_changelog_notifications = false;
+        imported_state.changelog_last_read_date = null;
 
         await upload_backup(page, {
             format_version: 1,
@@ -214,27 +371,52 @@ test.describe("Import and export easter egg", () => {
             state: imported_state,
             history: {},
         });
-        await page.locator("#merge-import-button").click();
+        await page.getByLabel("Merge all").check();
+        await page.locator("#continue-import-button").click();
 
-        await expect(page.locator("#import-conflict-title")).toHaveText("Settings for Alpha");
+        await expect(page.locator("#import-conflict-title")).toHaveText(
+            "Merge conflicts found for Alpha (1 of 4 conflicts)");
+        await expect(page.locator(".import-setting-name")).toHaveText(["Target number"]);
+        await expect(page.locator("#apply-import-choice-label")).toHaveText(
+            "Apply choice to remaining 2 users");
         await page.locator("#all-from-newer-button").click();
         await page.locator("input[name='import-setting-target_number'][value='local']").check();
         await page.locator("#next-import-conflict-button").click();
 
-        await expect(page.locator("#import-conflict-title")).toHaveText("Settings for Beta");
+        await expect(page.locator("#import-conflict-title")).toContainText("Beta (2 of 4");
+        await expect(page.locator(".import-setting-name")).toHaveText([
+            "Icon", "Target number",
+        ]);
+        await expect(page.locator(".import-setting-icon.fa-taxi")).toBeVisible();
+        await expect(page.locator("#apply-import-choice-label")).toHaveText(
+            "Apply choice to remaining 1 user");
         await page.locator("#apply-import-choice-to-all").check();
         await page.locator("#all-from-older-button").click();
         await page.locator("#next-import-conflict-button").click();
 
-        await expect(page.locator("#import-conflict-title")).toHaveText("Settings for Gamma");
+        await expect(page.locator("#import-conflict-title")).toContainText("Gamma (3 of 4");
         await expect(page.locator(
             "input[name='import-setting-target_number'][value='imported']")).toBeChecked();
+        await page.locator("#next-import-conflict-button").click();
+
+        await expect(page.locator("#import-conflict-title")).toHaveText(
+            "Merge conflicts found for Global settings (4 of 4 conflicts)");
+        await expect(page.locator("#import-conflict-description")).toContainText("app-wide");
+        await expect(page.locator(".import-setting-name")).toHaveText([
+            "Disable What's New notifications",
+        ]);
+        await expect(page.locator("#apply-import-choice-to-all").locator("xpath=..")).toBeHidden();
+        await page.locator("#all-from-newer-button").click();
         await page.locator("#next-import-conflict-button").click();
         await expect(page.locator("#play-button")).not.toHaveClass(/deactivated/);
 
         const after = await stored_data(page);
         expect(after.state.profiles["101"].target_number).toBe(25);
         expect(after.state.profiles["102"].target_number).toBe(30);
+        expect(after.state.profiles["102"].icon).toBe(local_profiles["102"].icon);
         expect(after.state.profiles["103"].target_number).toBe(60);
+        expect(after.state.suppress_changelog_notifications).toBe(true);
+        expect(after.state.changelog_last_read_date).toBe("9999-12-31");
+        await expect(page.locator("#i-infobox-trigger-container")).not.toHaveClass(/has-updates/);
     });
 });

--- a/index.html
+++ b/index.html
@@ -266,12 +266,16 @@ This is a method for teaching absolute pitch to children aged 2-6. Children shou
         >
         <i class="fa fa-adjust fa-fw" aria-hidden="true"></i>
     </a>
-    <a id="download-link" class="download-button colorscheme-toggle" onclick="download_state()">
-        <i class="fa fa-download fa-fw" aria-hidden="true"></i>
-    </a>
-    <a id="upload-link" class="download-button colorscheme-toggle" onclick="open_import_file_picker()">
-        <i class="fa fa-upload fa-fw" aria-hidden="true"></i>
-    </a>
+    <span class="transfer-button-container">
+        <a id="download-link" class="download-button colorscheme-toggle" onclick="download_state()"
+           aria-label="Download backup" title="Download backup">
+            <i class="fa fa-download fa-fw" aria-hidden="true"></i>
+        </a>
+        <a id="upload-link" class="download-button colorscheme-toggle" onclick="open_import_file_picker()"
+           aria-label="Upload backup" title="Upload backup">
+            <i class="fa fa-upload fa-fw" aria-hidden="true"></i>
+        </a>
+    </span>
     <input type="file" id="import-file-input" accept="application/json,.json"
            onchange="import_state_file(this)" hidden>
 </div>
@@ -454,37 +458,93 @@ This is a method for teaching absolute pitch to children aged 2-6. Children shou
     <button type="button" class="close-button" aria-label="Cancel import"
             onclick="cancel_import()">&times;</button>
     <div id="import-action-step">
-        <h2 id="import-state-title">Import backup</h2>
-        <p id="import-file-description"></p>
-        <p>Would you like to merge this backup with the data on this device,
-           or replace the data on this device?</p>
-        <div class="button-container">
-            <button type="button" id="merge-import-button"
-                    onclick="merge_import()">Merge</button>
-            <button type="button" id="replace-import-button"
-                    onclick="replace_import()">Replace</button>
-            <button type="button" id="cancel-import-button"
-                    onclick="cancel_import()">Cancel</button>
+        <h2 id="import-state-title">Choose what to import</h2>
+        <p id="import-file-description" class="import-file-description"></p>
+        <p id="import-followup-description" class="import-followup-description"></p>
+
+        <div id="import-single-profile" hidden>
+            <div class="import-profile-comparison">
+                <section class="import-profile-card" id="existing-profile-card">
+                    <h3>On this device</h3>
+                    <div id="existing-profile-summary"></div>
+                </section>
+                <section class="import-profile-card imported" id="incoming-profile-card">
+                    <h3>From backup</h3>
+                    <div id="incoming-profile-summary"></div>
+                </section>
+            </div>
+            <p id="single-profile-merge-description" class="import-merge-description"></p>
+            <div class="button-container import-button-container">
+                <button type="button" class="import-button primary" id="merge-import-button"
+                        onclick="select_single_import_action('merge')">Merge</button>
+                <button type="button" class="import-button" id="replace-import-button"
+                        onclick="select_single_import_action('replace')">Replace</button>
+                <button type="button" class="import-button" id="cancel-import-button"
+                        onclick="cancel_import()">Cancel</button>
+            </div>
+        </div>
+
+        <div id="import-multiple-profiles" hidden>
+            <div class="import-table-wrapper">
+                <table class="import-profile-table">
+                    <thead>
+                        <tr>
+                            <th rowspan="2">User</th>
+                            <th colspan="3">Existing</th>
+                            <th colspan="3">To be imported</th>
+                            <th rowspan="2">Merge</th>
+                            <th rowspan="2">Replace</th>
+                            <th rowspan="2">Don't import</th>
+                        </tr>
+                        <tr>
+                            <th>Start</th><th>End</th><th>Sessions</th>
+                            <th>Start</th><th>End</th><th>Sessions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="import-profile-table-body"></tbody>
+                    <tfoot>
+                        <tr class="import-select-all-row">
+                            <th>Select all:</th>
+                            <td colspan="6">
+                                <button type="button" class="import-button subtle"
+                                        id="clear-import-selections-button"
+                                        onclick="clear_import_selections()">Clear selections</button>
+                            </td>
+                            <td><input type="radio" name="select-all-import" value="merge"
+                                       aria-label="Merge all" onchange="select_all_import_profiles('merge')"></td>
+                            <td><input type="radio" name="select-all-import" value="replace"
+                                       aria-label="Replace all" onchange="select_all_import_profiles('replace')"></td>
+                            <td><input type="radio" name="select-all-import" value="skip"
+                                       aria-label="Don't import any" onchange="select_all_import_profiles('skip')"></td>
+                        </tr>
+                    </tfoot>
+                </table>
+            </div>
+            <div class="button-container import-button-container">
+                <button type="button" class="import-button primary" id="continue-import-button"
+                        onclick="continue_import_selection()" disabled>Continue</button>
+                <button type="button" class="import-button" onclick="cancel_import()">Cancel</button>
+            </div>
         </div>
     </div>
     <div id="import-conflict-step" hidden>
         <h2 id="import-conflict-title"></h2>
-        <p>Choose which value to keep for each setting.</p>
+        <p id="import-conflict-description">Choose which value to keep for each setting.</p>
         <div class="import-settings-grid" id="import-settings-grid"></div>
         <div class="import-all-controls">
-            <button type="button" id="all-from-newer-button"
+            <button type="button" class="import-button" id="all-from-newer-button"
                     onclick="choose_all_import_settings('newer')">All from newer</button>
             <label>
                 <input type="checkbox" id="apply-import-choice-to-all">
-                Apply choice to all users
+                <span id="apply-import-choice-label"></span>
             </label>
-            <button type="button" id="all-from-older-button"
+            <button type="button" class="import-button" id="all-from-older-button"
                     onclick="choose_all_import_settings('older')">All from older</button>
         </div>
-        <div class="button-container">
-            <button type="button" id="next-import-conflict-button"
+        <div class="button-container import-button-container">
+            <button type="button" class="import-button primary" id="next-import-conflict-button"
                     onclick="save_import_settings_choice()">Next user</button>
-            <button type="button" onclick="cancel_import()">Cancel</button>
+            <button type="button" class="import-button" onclick="cancel_import()">Cancel</button>
         </div>
     </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -269,6 +269,11 @@ This is a method for teaching absolute pitch to children aged 2-6. Children shou
     <a id="download-link" class="download-button colorscheme-toggle" onclick="download_state()">
         <i class="fa fa-download fa-fw" aria-hidden="true"></i>
     </a>
+    <a id="upload-link" class="download-button colorscheme-toggle" onclick="open_import_file_picker()">
+        <i class="fa fa-upload fa-fw" aria-hidden="true"></i>
+    </a>
+    <input type="file" id="import-file-input" accept="application/json,.json"
+           onchange="import_state_file(this)" hidden>
 </div>
 <!------------------------------------------------------>
 <!----------------------  Modals  ---------------------->
@@ -440,6 +445,47 @@ This is a method for teaching absolute pitch to children aged 2-6. Children shou
         <button class="button settings-button" id="delete-profile-button" onclick="delete_profile()">Delete Profile</button>
         <button class="button settings-button" id="submit-changes-button" onclick="submit_profile_changes()">Save Changes</button>
         <button class="button add-button" id="add-user-button" onclick="add_profile()">Add Profile</button>
+    </div>
+</div>
+
+<!-- Import / merge dialog (unlocked with the export easter egg) -->
+<div class="profile-info-container import-state-container" id="import-state-container"
+     role="dialog" aria-modal="true" aria-labelledby="import-state-title">
+    <button type="button" class="close-button" aria-label="Cancel import"
+            onclick="cancel_import()">&times;</button>
+    <div id="import-action-step">
+        <h2 id="import-state-title">Import backup</h2>
+        <p id="import-file-description"></p>
+        <p>Would you like to merge this backup with the data on this device,
+           or replace the data on this device?</p>
+        <div class="button-container">
+            <button type="button" id="merge-import-button"
+                    onclick="merge_import()">Merge</button>
+            <button type="button" id="replace-import-button"
+                    onclick="replace_import()">Replace</button>
+            <button type="button" id="cancel-import-button"
+                    onclick="cancel_import()">Cancel</button>
+        </div>
+    </div>
+    <div id="import-conflict-step" hidden>
+        <h2 id="import-conflict-title"></h2>
+        <p>Choose which value to keep for each setting.</p>
+        <div class="import-settings-grid" id="import-settings-grid"></div>
+        <div class="import-all-controls">
+            <button type="button" id="all-from-newer-button"
+                    onclick="choose_all_import_settings('newer')">All from newer</button>
+            <label>
+                <input type="checkbox" id="apply-import-choice-to-all">
+                Apply choice to all users
+            </label>
+            <button type="button" id="all-from-older-button"
+                    onclick="choose_all_import_settings('older')">All from older</button>
+        </div>
+        <div class="button-container">
+            <button type="button" id="next-import-conflict-button"
+                    onclick="save_import_settings_choice()">Next user</button>
+            <button type="button" onclick="cancel_import()">Cancel</button>
+        </div>
     </div>
 </div>
 <div class="shape-container">

--- a/js/cim.js
+++ b/js/cim.js
@@ -120,6 +120,12 @@ let _TONE_STARTED = false;
 let _SESSION_HISTORY = null;
 let _DOWNLOAD_ENABLED_CLICKS = 0;
 let _DOWNLOAD_ENABLED_LAST_CLICK = null;
+let _PENDING_IMPORT = null;
+let _IMPORT_MERGED_STATE = null;
+let _IMPORT_MERGED_HISTORY = null;
+let _IMPORT_CONFLICTS = [];
+let _IMPORT_CONFLICT_INDEX = 0;
+let _IMPORT_CHOICE_FOR_ALL = null;
 let _EASTER_EGG_CLICKS = 0;
 let _EASTER_EGG_LAST_CLICK = null;
 let _EASTER_EGG_ENABLED = false;
@@ -134,6 +140,17 @@ const _DEFAULT_CHORD_DISPLAY_MODE = "shapes_and_letters";
 const _DEFAULT_SINGLE_NOTE_MODE = "white_only_on_black";
 const _DEFAULT_SINGLE_NOTE_CORRECTNESS_MODE = "only_correct";
 const _DEFAULT_PERSIST_REACTION_FACE = false;
+const _PROFILE_SETTING_FIELDS = [
+    ["name", "Profile name"],
+    ["icon", "Icon"],
+    ["target_number", "Target number"],
+    ["show_chord_mode", "Show chord names"],
+    ["reveal_chord_mode", "Reveal chord names"],
+    ["chord_display_mode", "Chord name display"],
+    ["single_note_mode", "Single note trainer"],
+    ["single_note_correctness_mode", "Single note correctness"],
+    ["persist_reaction_face", "Persist reaction face"],
+];
 
 const _INFOBOX_TRIGGER_IDS = [
     "trainer-infobox-trigger",
@@ -1072,6 +1089,7 @@ function new_profile(name, icon, id, target_number=_DEFAULT_TARGET_NUMBER, show_
         single_note_mode: single_note_mode,
         single_note_correctness_mode: single_note_correctness_mode,
         persist_reaction_face: persist_reaction_face,
+        settings_updated_time: get_current_timestamp(),
         stats: new_stats(),
         current_chord: _DEFAULT_CHORD,
         current_instrument: _DEFAULT_INSTRUMENT,
@@ -1491,6 +1509,7 @@ function submit_profile_changes() {
     current_profile.single_note_mode = profile_values.single_note_mode;
     current_profile.single_note_correctness_mode = profile_values.single_note_correctness_mode;
     current_profile.persist_reaction_face = profile_values.persist_reaction_face;
+    current_profile.settings_updated_time = get_current_timestamp();
 
     STATE.suppress_changelog_notifications =
         document.getElementById("suppress_changelog_notifications_setting").checked;
@@ -1757,6 +1776,7 @@ function enable_download() {
 
     let elem = document.getElementById("download-link");
     elem.classList.add("visible");
+    document.getElementById("upload-link").classList.add("visible");
 }
 
 function trigger_easter_egg() {
@@ -1790,6 +1810,8 @@ function trigger_easter_egg() {
 
 function download_state() {
     const state_json = JSON.stringify({
+        format_version: 1,
+        exported_at: get_current_timestamp(),
         state: STATE,
         history: get_session_history()
     }, null, 2);
@@ -1800,6 +1822,341 @@ function download_state() {
     download_elem.download = "cim_state_" + Math.round(get_current_timestamp()) + ".json"
     download_elem.click();
     download_elem.remove();
+}
+
+function open_import_file_picker() {
+    document.getElementById("import-file-input").click();
+}
+
+function reset_import_dialog() {
+    _PENDING_IMPORT = null;
+    _IMPORT_MERGED_STATE = null;
+    _IMPORT_MERGED_HISTORY = null;
+    _IMPORT_CONFLICTS = [];
+    _IMPORT_CONFLICT_INDEX = 0;
+    _IMPORT_CHOICE_FOR_ALL = null;
+
+    const file_input = document.getElementById("import-file-input");
+    file_input.value = "";
+    document.getElementById("import-action-step").hidden = false;
+    document.getElementById("import-conflict-step").hidden = true;
+    document.getElementById("apply-import-choice-to-all").checked = false;
+}
+
+function cancel_import() {
+    document.getElementById("import-state-container").classList.remove("visible");
+    reset_import_dialog();
+}
+
+function validate_import(imported) {
+    if (imported === null || typeof imported !== "object" ||
+        imported.state === null || typeof imported.state !== "object" ||
+        imported.state.profiles === null || typeof imported.state.profiles !== "object" ||
+        Array.isArray(imported.state.profiles)) {
+        throw new Error("This file is not a CIM backup.");
+    }
+
+    for (const profile of Object.values(imported.state.profiles)) {
+        if (profile === null || typeof profile !== "object" ||
+            (typeof profile.id !== "number" && typeof profile.id !== "string") ||
+            !Number.isFinite(Number(profile.id)) ||
+            typeof profile.name !== "string" || typeof profile.icon !== "string" ||
+            !Number.isInteger(Number(profile.target_number)) ||
+            Number(profile.target_number) < 1) {
+            throw new Error("The backup contains an invalid profile.");
+        }
+        initialize_profile_defaults(profile);
+    }
+
+    if (imported.history === undefined || imported.history === null) {
+        imported.history = {};
+    }
+    if (typeof imported.history !== "object" || Array.isArray(imported.history)) {
+        throw new Error("The backup's session history is invalid.");
+    }
+    for (const profile_history of Object.values(imported.history)) {
+        if (profile_history === null || typeof profile_history !== "object" ||
+            Array.isArray(profile_history) ||
+            Object.values(profile_history).some((sessions) => !Array.isArray(sessions))) {
+            throw new Error("The backup's session history is invalid.");
+        }
+    }
+
+    return imported;
+}
+
+async function import_state_file(file_input) {
+    const file = file_input.files[0];
+    if (file === undefined) {
+        return;
+    }
+
+    try {
+        _PENDING_IMPORT = validate_import(JSON.parse(await file.text()));
+    } catch (error) {
+        alert("Could not import this file: " + error.message);
+        reset_import_dialog();
+        return;
+    }
+
+    document.getElementById("import-file-description").textContent =
+        "Selected backup: " + file.name;
+    document.getElementById("import-state-container").classList.add("visible");
+}
+
+function install_imported_data(state, history) {
+    localStorage.setObject(STATE_KEY, state);
+    localStorage.setObject(SESSION_HISTORY_KEY, history);
+    window.location.reload();
+}
+
+function replace_import() {
+    install_imported_data(_PENDING_IMPORT.state, _PENDING_IMPORT.history);
+}
+
+function clone_object(value) {
+    if (value === undefined) {
+        return undefined;
+    }
+    return JSON.parse(JSON.stringify(value));
+}
+
+function profile_settings_differ(first, second) {
+    return _PROFILE_SETTING_FIELDS.some(
+        ([field]) => JSON.stringify(first[field]) !== JSON.stringify(second[field]));
+}
+
+function profile_settings_timestamp(profile, backup_timestamp=null) {
+    if (Number.isFinite(profile.settings_updated_time)) {
+        return profile.settings_updated_time;
+    }
+    if (Number.isFinite(backup_timestamp) && backup_timestamp > 0) {
+        return backup_timestamp;
+    }
+    if (profile.stats !== undefined && Number.isFinite(profile.stats.updated_time)) {
+        return profile.stats.updated_time;
+    }
+    return 0;
+}
+
+function current_backup_timestamp() {
+    return Math.max(0, ...Object.values(STATE.profiles).map(
+        (profile) => profile_settings_timestamp(profile)));
+}
+
+function next_profile_id(profiles) {
+    let id = _GUEST_USER_ID + 1;
+    while (Object.prototype.hasOwnProperty.call(profiles, id)) {
+        id++;
+    }
+    return id;
+}
+
+function find_merge_profile_id(profiles, imported_profile) {
+    const imported_id = String(imported_profile.id);
+    const profile_at_id = profiles[imported_id];
+    if (profile_at_id !== undefined &&
+        (imported_profile.id == _GUEST_USER_ID ||
+         profile_at_id.name.toLowerCase() === imported_profile.name.toLowerCase())) {
+        return imported_id;
+    }
+
+    const matching_name = Object.values(profiles).find(
+        (profile) => profile.name.toLowerCase() === imported_profile.name.toLowerCase());
+    return matching_name === undefined ? null : String(matching_name.id);
+}
+
+function merge_session_arrays(current_sessions, imported_sessions) {
+    const sessions = [...(current_sessions || []), ...(imported_sessions || [])];
+    const unique_sessions = new Map();
+    for (const session of sessions) {
+        const key = [session.start_time, session.updated_time,
+                     session.identifications, session.current_chord].join("|");
+        unique_sessions.set(key, clone_object(session));
+    }
+    return Array.from(unique_sessions.values()).sort(
+        (first, second) => (first.start_time || 0) - (second.start_time || 0));
+}
+
+function merge_profile_history(target_history, imported_history) {
+    for (const [chord, sessions] of Object.entries(imported_history || {})) {
+        target_history[chord] = merge_session_arrays(target_history[chord], sessions);
+    }
+}
+
+function newer_profile(first, second) {
+    const first_time = first.stats?.updated_time || 0;
+    const second_time = second.stats?.updated_time || 0;
+    return first_time >= second_time ? first : second;
+}
+
+function merge_import() {
+    const imported_state = _PENDING_IMPORT.state;
+    const imported_history = _PENDING_IMPORT.history;
+    const imported_timestamp = Number(_PENDING_IMPORT.exported_at) || 0;
+    const local_timestamp = current_backup_timestamp();
+    const imported_to_merged_ids = {};
+
+    _IMPORT_MERGED_STATE = clone_object(STATE);
+    _IMPORT_MERGED_HISTORY = clone_object(get_session_history());
+    _IMPORT_CONFLICTS = [];
+
+    for (const imported_profile of Object.values(imported_state.profiles)) {
+        let target_id = find_merge_profile_id(
+            _IMPORT_MERGED_STATE.profiles, imported_profile);
+        if (target_id === null) {
+            target_id = String(imported_profile.id);
+            if (Object.prototype.hasOwnProperty.call(
+                    _IMPORT_MERGED_STATE.profiles, target_id)) {
+                target_id = String(next_profile_id(_IMPORT_MERGED_STATE.profiles));
+            }
+            const added_profile = clone_object(imported_profile);
+            added_profile.id = Number(target_id);
+            _IMPORT_MERGED_STATE.profiles[target_id] = added_profile;
+        } else {
+            const local_profile = _IMPORT_MERGED_STATE.profiles[target_id];
+            const base_profile = clone_object(newer_profile(local_profile, imported_profile));
+            base_profile.id = local_profile.id;
+            _IMPORT_MERGED_STATE.profiles[target_id] = base_profile;
+
+            if (profile_settings_differ(local_profile, imported_profile)) {
+                const local_settings_time =
+                    profile_settings_timestamp(local_profile, local_timestamp);
+                const imported_settings_time =
+                    profile_settings_timestamp(imported_profile, imported_timestamp);
+                _IMPORT_CONFLICTS.push({
+                    target_id: target_id,
+                    local: clone_object(local_profile),
+                    imported: clone_object(imported_profile),
+                    newer: imported_settings_time > local_settings_time
+                        ? "imported" : "local",
+                });
+            }
+        }
+        imported_to_merged_ids[String(imported_profile.id)] = target_id;
+    }
+
+    for (const [imported_id, profile_history] of Object.entries(imported_history)) {
+        const target_id = imported_to_merged_ids[imported_id] || imported_id;
+        if (_IMPORT_MERGED_HISTORY[target_id] === undefined) {
+            _IMPORT_MERGED_HISTORY[target_id] = {};
+        }
+        merge_profile_history(_IMPORT_MERGED_HISTORY[target_id], profile_history);
+    }
+
+    _IMPORT_MERGED_STATE.changelog_last_read_date = Math.max(
+        _IMPORT_MERGED_STATE.changelog_last_read_date || 0,
+        imported_state.changelog_last_read_date || 0) || null;
+    if (imported_timestamp > local_timestamp &&
+        imported_state.suppress_changelog_notifications !== undefined) {
+        _IMPORT_MERGED_STATE.suppress_changelog_notifications =
+            imported_state.suppress_changelog_notifications;
+    }
+
+    if (_IMPORT_CONFLICTS.length === 0) {
+        install_imported_data(_IMPORT_MERGED_STATE, _IMPORT_MERGED_HISTORY);
+        return;
+    }
+
+    _IMPORT_CONFLICT_INDEX = 0;
+    document.getElementById("import-action-step").hidden = true;
+    document.getElementById("import-conflict-step").hidden = false;
+    populate_import_settings_conflict();
+}
+
+function setting_display_value(field, value) {
+    if (field === "icon") {
+        return String(value).replace(/^fa-/, "").replaceAll("-", " ");
+    }
+    if (typeof value === "boolean") {
+        return value ? "Yes" : "No";
+    }
+    return String(value).replaceAll("_", " ");
+}
+
+function populate_import_settings_conflict() {
+    const conflict = _IMPORT_CONFLICTS[_IMPORT_CONFLICT_INDEX];
+    const grid = document.getElementById("import-settings-grid");
+    grid.replaceChildren();
+    document.getElementById("import-conflict-title").textContent =
+        "Settings for " + conflict.local.name;
+
+    const local_age = conflict.newer === "local" ? "newer" : "older";
+    const imported_age = conflict.newer === "imported" ? "newer" : "older";
+    for (const heading of [
+            "Setting",
+            "On this device (" + local_age + ")",
+            "From backup (" + imported_age + ")"]) {
+        const element = document.createElement("div");
+        element.className = "import-setting-heading";
+        element.textContent = heading;
+        grid.appendChild(element);
+    }
+
+    const selected_side = _IMPORT_CHOICE_FOR_ALL === null
+        ? conflict.newer
+        : (_IMPORT_CHOICE_FOR_ALL === "newer"
+            ? conflict.newer
+            : (conflict.newer === "local" ? "imported" : "local"));
+
+    for (const [field, label] of _PROFILE_SETTING_FIELDS) {
+        const label_element = document.createElement("div");
+        label_element.textContent = label;
+        grid.appendChild(label_element);
+
+        for (const side of ["local", "imported"]) {
+            const value_label = document.createElement("label");
+            value_label.className = "import-setting-value";
+            const radio = document.createElement("input");
+            radio.type = "radio";
+            radio.name = "import-setting-" + field;
+            radio.value = side;
+            radio.checked = side === selected_side;
+            value_label.appendChild(radio);
+            value_label.append(setting_display_value(field, conflict[side][field]));
+            grid.appendChild(value_label);
+        }
+    }
+
+    const next_button = document.getElementById("next-import-conflict-button");
+    next_button.textContent = _IMPORT_CONFLICT_INDEX === _IMPORT_CONFLICTS.length - 1
+        ? "Finish import" : "Next user";
+}
+
+function choose_all_import_settings(age) {
+    const conflict = _IMPORT_CONFLICTS[_IMPORT_CONFLICT_INDEX];
+    const side = age === "newer"
+        ? conflict.newer
+        : (conflict.newer === "local" ? "imported" : "local");
+    for (const radio of document.querySelectorAll(
+            "#import-settings-grid input[type='radio'][value='" + side + "']")) {
+        radio.checked = true;
+    }
+
+    if (document.getElementById("apply-import-choice-to-all").checked) {
+        _IMPORT_CHOICE_FOR_ALL = age;
+    }
+}
+
+function save_import_settings_choice() {
+    const conflict = _IMPORT_CONFLICTS[_IMPORT_CONFLICT_INDEX];
+    const merged_profile = _IMPORT_MERGED_STATE.profiles[conflict.target_id];
+    for (const [field] of _PROFILE_SETTING_FIELDS) {
+        const selected = document.querySelector(
+            "input[name='import-setting-" + field + "']:checked").value;
+        merged_profile[field] = clone_object(conflict[selected][field]);
+    }
+    merged_profile.settings_updated_time = Math.max(
+        profile_settings_timestamp(conflict.local),
+        profile_settings_timestamp(
+            conflict.imported, Number(_PENDING_IMPORT.exported_at) || 0));
+
+    _IMPORT_CONFLICT_INDEX++;
+    if (_IMPORT_CONFLICT_INDEX === _IMPORT_CONFLICTS.length) {
+        install_imported_data(_IMPORT_MERGED_STATE, _IMPORT_MERGED_HISTORY);
+        return;
+    }
+    populate_import_settings_conflict();
 }
 
 const WEEK_SECONDS = 7 * 24 * 3600;

--- a/js/cim.js
+++ b/js/cim.js
@@ -121,6 +121,7 @@ let _SESSION_HISTORY = null;
 let _DOWNLOAD_ENABLED_CLICKS = 0;
 let _DOWNLOAD_ENABLED_LAST_CLICK = null;
 let _PENDING_IMPORT = null;
+let _IMPORT_PROFILE_PLANS = [];
 let _IMPORT_MERGED_STATE = null;
 let _IMPORT_MERGED_HISTORY = null;
 let _IMPORT_CONFLICTS = [];
@@ -150,6 +151,9 @@ const _PROFILE_SETTING_FIELDS = [
     ["single_note_mode", "Single note trainer"],
     ["single_note_correctness_mode", "Single note correctness"],
     ["persist_reaction_face", "Persist reaction face"],
+];
+const _GLOBAL_SETTING_FIELDS = [
+    ["suppress_changelog_notifications", "Disable What's New notifications"],
 ];
 
 const _INFOBOX_TRIGGER_IDS = [
@@ -1830,6 +1834,7 @@ function open_import_file_picker() {
 
 function reset_import_dialog() {
     _PENDING_IMPORT = null;
+    _IMPORT_PROFILE_PLANS = [];
     _IMPORT_MERGED_STATE = null;
     _IMPORT_MERGED_HISTORY = null;
     _IMPORT_CONFLICTS = [];
@@ -1840,12 +1845,52 @@ function reset_import_dialog() {
     file_input.value = "";
     document.getElementById("import-action-step").hidden = false;
     document.getElementById("import-conflict-step").hidden = true;
+    document.getElementById("import-single-profile").hidden = true;
+    document.getElementById("import-multiple-profiles").hidden = true;
     document.getElementById("apply-import-choice-to-all").checked = false;
 }
 
 function cancel_import() {
     document.getElementById("import-state-container").classList.remove("visible");
     reset_import_dialog();
+}
+
+function import_value_description(value) {
+    if (value === undefined) {
+        return "missing";
+    }
+    return JSON.stringify(value);
+}
+
+function invalid_import_profile(profile, field, requirement) {
+    const name = typeof profile.name === "string" ? profile.name : "<unnamed>";
+    const id = profile.id === undefined ? "missing" : import_value_description(profile.id);
+    throw new Error(
+        "Profile \"" + name + "\" (ID " + id + "): `" + field + "` " + requirement +
+        "; got " + import_value_description(profile[field]) + ".");
+}
+
+function validate_import_profile_choice(profile, field, choices) {
+    if (!choices.includes(profile[field])) {
+        invalid_import_profile(
+            profile, field, "must be one of " + choices.map(
+                (choice) => "`" + choice + "`").join(", "));
+    }
+}
+
+function migrate_imported_profile(profile) {
+    // Older backups predate these settings. A null target also appeared in
+    // backups produced while an empty target field was accepted by the UI.
+    if (profile.target_number === undefined || profile.target_number === null) {
+        profile.target_number = _DEFAULT_TARGET_NUMBER;
+    }
+    if (profile.current_chord === undefined || profile.current_chord === null) {
+        profile.current_chord = _DEFAULT_CHORD;
+    }
+    if (profile.current_instrument === undefined || profile.current_instrument === null) {
+        profile.current_instrument = _DEFAULT_INSTRUMENT;
+    }
+    initialize_profile_defaults(profile);
 }
 
 function validate_import(imported) {
@@ -1857,15 +1902,51 @@ function validate_import(imported) {
     }
 
     for (const profile of Object.values(imported.state.profiles)) {
-        if (profile === null || typeof profile !== "object" ||
-            (typeof profile.id !== "number" && typeof profile.id !== "string") ||
-            !Number.isFinite(Number(profile.id)) ||
-            typeof profile.name !== "string" || typeof profile.icon !== "string" ||
-            !Number.isInteger(Number(profile.target_number)) ||
-            Number(profile.target_number) < 1) {
-            throw new Error("The backup contains an invalid profile.");
+        if (profile === null || typeof profile !== "object" || Array.isArray(profile)) {
+            throw new Error("The backup contains a profile that is not an object.");
         }
-        initialize_profile_defaults(profile);
+        if ((typeof profile.id !== "number" && typeof profile.id !== "string") ||
+            !Number.isFinite(Number(profile.id))) {
+            invalid_import_profile(profile, "id", "must be a numeric ID");
+        }
+        if (typeof profile.name !== "string" || profile.name.length === 0) {
+            invalid_import_profile(profile, "name", "must be a non-empty string");
+        }
+        if (typeof profile.icon !== "string" || profile.icon.length === 0) {
+            invalid_import_profile(profile, "icon", "must be a non-empty string");
+        }
+
+        migrate_imported_profile(profile);
+        if (!Number.isInteger(Number(profile.target_number)) ||
+            Number(profile.target_number) < 1) {
+            invalid_import_profile(
+                profile, "target_number", "must be a positive integer");
+        }
+        if (profile.stats === null || typeof profile.stats !== "object" ||
+            Array.isArray(profile.stats)) {
+            invalid_import_profile(profile, "stats", "must be an object");
+        }
+        validate_import_profile_choice(
+            profile, "current_chord", Object.keys(CHORDS_TONE));
+        validate_import_profile_choice(
+            profile, "current_instrument", Object.keys(INSTRUMENT_INFO));
+        validate_import_profile_choice(
+            profile, "show_chord_mode", ["always", "black_only", "never"]);
+        validate_import_profile_choice(
+            profile, "reveal_chord_mode", ["always", "after_guess"]);
+        validate_import_profile_choice(
+            profile, "chord_display_mode",
+            ["shapes_and_letters", "shapes_only", "letters_only"]);
+        validate_import_profile_choice(
+            profile, "single_note_mode",
+            ["white_only_on_black", "all_on_black", "always", "never"]);
+        validate_import_profile_choice(
+            profile, "single_note_correctness_mode",
+            ["only_correct", "only_incorrect", "always"]);
+        if (typeof profile.persist_reaction_face !== "boolean") {
+            invalid_import_profile(
+                profile, "persist_reaction_face", "must be a boolean");
+        }
     }
 
     if (imported.history === undefined || imported.history === null) {
@@ -1874,15 +1955,51 @@ function validate_import(imported) {
     if (typeof imported.history !== "object" || Array.isArray(imported.history)) {
         throw new Error("The backup's session history is invalid.");
     }
-    for (const profile_history of Object.values(imported.history)) {
+    for (const [profile_id, profile_history] of Object.entries(imported.history)) {
         if (profile_history === null || typeof profile_history !== "object" ||
-            Array.isArray(profile_history) ||
-            Object.values(profile_history).some((sessions) => !Array.isArray(sessions))) {
-            throw new Error("The backup's session history is invalid.");
+            Array.isArray(profile_history)) {
+            throw new Error(
+                "Session history for profile ID " + profile_id + " must be an object; got " +
+                import_value_description(profile_history) + ".");
+        }
+        for (const [chord, sessions] of Object.entries(profile_history)) {
+            if (!Array.isArray(sessions)) {
+                throw new Error(
+                    "Session history for profile ID " + profile_id + ", chord `" + chord +
+                    "` must be an array; got " + import_value_description(sessions) + ".");
+            }
         }
     }
 
+    if (imported.state.changelog_last_read_date === undefined) {
+        imported.state.changelog_last_read_date = null;
+    }
+    if (imported.state.suppress_changelog_notifications === undefined) {
+        imported.state.suppress_changelog_notifications = false;
+    }
+
     return imported;
+}
+
+function latest_backup_data_timestamp(imported) {
+    let latest = 0;
+    for (const profile of Object.values(imported.state.profiles)) {
+        latest = Math.max(
+            latest,
+            Number(profile.settings_updated_time) || 0,
+            Number(profile.stats?.updated_time) || 0);
+    }
+    for (const profile_history of Object.values(imported.history)) {
+        for (const sessions of Object.values(profile_history)) {
+            for (const session of sessions) {
+                latest = Math.max(
+                    latest,
+                    Number(session.updated_time) || 0,
+                    Number(session.start_time) || 0);
+            }
+        }
+    }
+    return latest;
 }
 
 async function import_state_file(file_input) {
@@ -1899,8 +2016,20 @@ async function import_state_file(file_input) {
         return;
     }
 
+    if (!Number.isFinite(Number(_PENDING_IMPORT.exported_at)) ||
+        Number(_PENDING_IMPORT.exported_at) <= 0) {
+        _PENDING_IMPORT.exported_at = latest_backup_data_timestamp(_PENDING_IMPORT);
+    }
+
     document.getElementById("import-file-description").textContent =
         "Selected backup: " + file.name;
+    try {
+        prepare_import_preview();
+    } catch (error) {
+        alert("Could not import this file: " + error.message);
+        reset_import_dialog();
+        return;
+    }
     document.getElementById("import-state-container").classList.add("visible");
 }
 
@@ -1908,10 +2037,6 @@ function install_imported_data(state, history) {
     localStorage.setObject(STATE_KEY, state);
     localStorage.setObject(SESSION_HISTORY_KEY, history);
     window.location.reload();
-}
-
-function replace_import() {
-    install_imported_data(_PENDING_IMPORT.state, _PENDING_IMPORT.history);
 }
 
 function clone_object(value) {
@@ -1922,7 +2047,11 @@ function clone_object(value) {
 }
 
 function profile_settings_differ(first, second) {
-    return _PROFILE_SETTING_FIELDS.some(
+    return differing_settings(first, second, _PROFILE_SETTING_FIELDS).length > 0;
+}
+
+function differing_settings(first, second, fields) {
+    return fields.filter(
         ([field]) => JSON.stringify(first[field]) !== JSON.stringify(second[field]));
 }
 
@@ -1966,6 +2095,323 @@ function find_merge_profile_id(profiles, imported_profile) {
     return matching_name === undefined ? null : String(matching_name.id);
 }
 
+function profile_sessions(profile_history) {
+    const sessions = Object.values(profile_history || {}).flat()
+        .filter((session) => Number(session.identifications) > 0)
+        .map((session) => clone_object(session));
+
+    const unique = new Map();
+    for (const session of sessions) {
+        const key = [session.start_time, session.updated_time,
+                     session.identifications, session.current_chord].join("|");
+        unique.set(key, session);
+    }
+    return Array.from(unique.values()).sort(
+        (first, second) => (first.start_time || 0) - (second.start_time || 0));
+}
+
+function summarize_profile(profile, profile_history) {
+    const sessions = profile_sessions(profile_history);
+    const first = sessions.reduce((earliest, session) =>
+        earliest === null || Number(session.start_time) < Number(earliest.start_time)
+            ? session : earliest, null);
+    const last = sessions.reduce((latest, session) =>
+        latest === null || Number(session.updated_time) > Number(latest.updated_time)
+            ? session : latest, null);
+    return {
+        sessions: sessions.length,
+        first: first,
+        last: last,
+        last_updated: Number(profile.stats?.updated_time) || 0,
+    };
+}
+
+function profile_has_importable_data(profile, profile_history) {
+    if (summarize_profile(profile, profile_history).sessions > 0 ||
+        Number(profile.stats?.identifications) > 0 ||
+        profile.current_chord !== _DEFAULT_CHORD ||
+        profile.current_instrument !== _DEFAULT_INSTRUMENT) {
+        return true;
+    }
+    if (profile.id != _GUEST_USER_ID) {
+        return true;
+    }
+
+    const defaults = {
+        name: "Guest",
+        icon: "fa-user",
+        target_number: _DEFAULT_TARGET_NUMBER,
+        show_chord_mode: _DEFAULT_SHOW_CHORD_MODE,
+        reveal_chord_mode: _DEFAULT_REVEAL_CHORD_MODE,
+        chord_display_mode: _DEFAULT_CHORD_DISPLAY_MODE,
+        single_note_mode: _DEFAULT_SINGLE_NOTE_MODE,
+        single_note_correctness_mode: _DEFAULT_SINGLE_NOTE_CORRECTNESS_MODE,
+        persist_reaction_face: _DEFAULT_PERSIST_REACTION_FACE,
+    };
+    return profile_settings_differ(profile, defaults);
+}
+
+function format_import_date(timestamp) {
+    return timestamp ? format_date(new Date(timestamp * 1000)) : "—";
+}
+
+function profile_conflict_count(local_profile, imported_profile) {
+    if (local_profile === null) {
+        return 0;
+    }
+    return differing_settings(
+        local_profile, imported_profile, _PROFILE_SETTING_FIELDS).length;
+}
+
+function prepare_import_preview() {
+    const imported_profiles = Object.values(_PENDING_IMPORT.state.profiles)
+        .filter((profile) => profile_has_importable_data(
+            profile, _PENDING_IMPORT.history[String(profile.id)]));
+    _IMPORT_PROFILE_PLANS = imported_profiles.map((profile) => {
+        const target_id = find_merge_profile_id(STATE.profiles, profile);
+        const local_profile = target_id === null ? null : STATE.profiles[target_id];
+        return {
+            imported_id: String(profile.id),
+            target_id: target_id,
+            local: local_profile,
+            imported: profile,
+            action: null,
+            conflicts: profile_conflict_count(local_profile, profile),
+        };
+    });
+
+    if (_IMPORT_PROFILE_PLANS.length === 0) {
+        throw new Error("This backup has no profiles with history or non-default settings.");
+    }
+
+    const profile_word = _IMPORT_PROFILE_PLANS.length === 1 ? "profile" : "profiles";
+    const session_count = _IMPORT_PROFILE_PLANS.reduce((total, plan) =>
+        total + summarize_profile(
+            plan.imported, _PENDING_IMPORT.history[plan.imported_id]).sessions, 0);
+    const global_conflict = differing_settings(
+        STATE, _PENDING_IMPORT.state, _GLOBAL_SETTING_FIELDS).length > 0;
+    const profile_conflicts = _IMPORT_PROFILE_PLANS.filter(
+        (plan) => plan.conflicts > 0).length;
+    const followups = profile_conflicts + (global_conflict ? 1 : 0);
+    document.getElementById("import-followup-description").textContent =
+        "The backup contains " + _IMPORT_PROFILE_PLANS.length + " " + profile_word +
+        " and " + session_count + " completed " +
+        (session_count === 1 ? "session" : "sessions") + ". " +
+        (followups === 0
+            ? "All merges can happen automatically."
+            : "Depending on your selections, up to " + followups + " settings " +
+              (followups === 1 ? "choice" : "choices") + " will follow.");
+    document.getElementById("import-followup-description").textContent +=
+        " Replace only replaces the selected profile; other profiles on this device are kept.";
+
+    if (_IMPORT_PROFILE_PLANS.length === 1) {
+        populate_single_profile_preview(_IMPORT_PROFILE_PLANS[0]);
+    } else {
+        populate_multiple_profile_preview();
+    }
+}
+
+function append_profile_identity(container, profile) {
+    const identity = document.createElement("div");
+    identity.className = "import-profile-identity";
+    const icon = document.createElement("i");
+    icon.className = "fa fa-solid " + profile.icon;
+    icon.setAttribute("aria-hidden", "true");
+    const name = document.createElement("span");
+    name.textContent = profile.name;
+    identity.append(icon, name);
+    container.appendChild(identity);
+}
+
+function append_color_date(container, session, date_field) {
+    const dot = document.createElement("div");
+    dot.className = "import-color-dot " + session.current_chord;
+    dot.title = session.current_chord;
+    const date = document.createElement("span");
+    date.textContent = format_import_date(session[date_field]);
+    container.append(dot, date);
+}
+
+function render_profile_summary(container, profile, profile_history) {
+    container.replaceChildren();
+    if (profile === null) {
+        const empty = document.createElement("p");
+        empty.textContent = "No matching profile on this device.";
+        empty.className = "import-merge-description";
+        container.appendChild(empty);
+        return;
+    }
+
+    append_profile_identity(container, profile);
+    const summary = summarize_profile(profile, profile_history);
+    const details = document.createElement("dl");
+    details.className = "import-profile-detail";
+
+    const append_detail = (label, value) => {
+        const term = document.createElement("dt");
+        term.textContent = label;
+        const description = document.createElement("dd");
+        if (typeof value === "string") {
+            description.textContent = value;
+        } else {
+            description.appendChild(value);
+        }
+        details.append(term, description);
+    };
+
+    if (summary.sessions === 0) {
+        append_detail("History", "No completed sessions");
+    } else {
+        const endpoints = document.createElement("span");
+        endpoints.className = "import-history-endpoints";
+        append_color_date(endpoints, summary.first, "start_time");
+        const separator = document.createElement("span");
+        separator.textContent = "–";
+        endpoints.appendChild(separator);
+        append_color_date(endpoints, summary.last, "updated_time");
+        append_detail("History", endpoints);
+    }
+    append_detail("Sessions", String(summary.sessions));
+    const current = document.createElement("span");
+    current.className = "import-history-endpoints";
+    append_color_date(current, {
+        current_chord: profile.current_chord,
+        updated_time: summary.last_updated,
+    }, "updated_time");
+    append_detail("Current", current);
+    container.appendChild(details);
+}
+
+function populate_single_profile_preview(plan) {
+    document.getElementById("import-single-profile").hidden = false;
+    document.getElementById("import-multiple-profiles").hidden = true;
+    render_profile_summary(
+        document.getElementById("existing-profile-summary"),
+        plan.local,
+        plan.target_id === null ? {} : get_session_history()[plan.target_id]);
+    render_profile_summary(
+        document.getElementById("incoming-profile-summary"),
+        plan.imported,
+        _PENDING_IMPORT.history[plan.imported_id]);
+
+    const description = plan.local === null
+        ? "This is a new profile, so merging can happen automatically."
+        : (plan.conflicts === 0
+            ? "The profile settings agree, so merging can happen automatically."
+            : "Merging will require one settings choice screen for this profile.");
+    document.getElementById("single-profile-merge-description").textContent = description;
+}
+
+function append_table_cell(row, value) {
+    const cell = document.createElement("td");
+    cell.textContent = value;
+    row.appendChild(cell);
+}
+
+function append_table_summary(row, profile, profile_history) {
+    if (profile === null) {
+        const cell = document.createElement("td");
+        cell.colSpan = 3;
+        cell.textContent = "New profile";
+        row.appendChild(cell);
+        return;
+    }
+    const summary = summarize_profile(profile, profile_history);
+    append_table_cell(row, format_import_date(summary.first?.start_time));
+    append_table_cell(row, format_import_date(summary.last?.updated_time));
+    append_table_cell(row, String(summary.sessions));
+}
+
+function populate_multiple_profile_preview() {
+    document.getElementById("import-single-profile").hidden = true;
+    document.getElementById("import-multiple-profiles").hidden = false;
+    const body = document.getElementById("import-profile-table-body");
+    body.replaceChildren();
+
+    for (const [index, plan] of _IMPORT_PROFILE_PLANS.entries()) {
+        const row = document.createElement("tr");
+        const heading = document.createElement("th");
+        heading.scope = "row";
+        const identity = document.createElement("span");
+        identity.className = "import-table-profile-name";
+        const icon = document.createElement("i");
+        icon.className = "fa fa-solid " + plan.imported.icon;
+        const name = document.createElement("span");
+        name.textContent = plan.imported.name;
+        identity.append(icon, name);
+        heading.appendChild(identity);
+        const conflict_note = document.createElement("span");
+        conflict_note.className = "import-table-conflicts";
+        conflict_note.textContent = plan.conflicts === 0
+            ? "Automatic merge"
+            : plan.conflicts + " setting " +
+              (plan.conflicts === 1 ? "difference" : "differences");
+        heading.appendChild(conflict_note);
+        row.appendChild(heading);
+
+        append_table_summary(
+            row,
+            plan.local,
+            plan.target_id === null ? {} : get_session_history()[plan.target_id]);
+        append_table_summary(
+            row, plan.imported, _PENDING_IMPORT.history[plan.imported_id]);
+
+        for (const action of ["merge", "replace", "skip"]) {
+            const cell = document.createElement("td");
+            const radio = document.createElement("input");
+            radio.type = "radio";
+            radio.name = "import-profile-" + index;
+            radio.value = action;
+            const action_label = action === "skip" ? "Don't import" :
+                action[0].toUpperCase() + action.slice(1);
+            radio.setAttribute(
+                "aria-label", action_label + " " + plan.imported.name);
+            radio.addEventListener("change", () => {
+                plan.action = action;
+                update_import_continue_button();
+            });
+            cell.appendChild(radio);
+            row.appendChild(cell);
+        }
+        body.appendChild(row);
+    }
+    update_import_continue_button();
+}
+
+function update_import_continue_button() {
+    document.getElementById("continue-import-button").disabled =
+        _IMPORT_PROFILE_PLANS.some((plan) => plan.action === null);
+}
+
+function clear_import_selections() {
+    for (const radio of document.querySelectorAll(
+            ".import-profile-table input[type='radio']")) {
+        radio.checked = false;
+    }
+    for (const plan of _IMPORT_PROFILE_PLANS) {
+        plan.action = null;
+    }
+    update_import_continue_button();
+}
+
+function select_all_import_profiles(action) {
+    for (const [index, plan] of _IMPORT_PROFILE_PLANS.entries()) {
+        plan.action = action;
+        document.querySelector(
+            "input[name='import-profile-" + index + "'][value='" + action + "']").checked = true;
+    }
+    update_import_continue_button();
+}
+
+function select_single_import_action(action) {
+    _IMPORT_PROFILE_PLANS[0].action = action;
+    continue_import_selection();
+}
+
+function continue_import_selection() {
+    apply_import_plan();
+}
+
 function merge_session_arrays(current_sessions, imported_sessions) {
     const sessions = [...(current_sessions || []), ...(imported_sessions || [])];
     const unique_sessions = new Map();
@@ -1990,20 +2436,34 @@ function newer_profile(first, second) {
     return first_time >= second_time ? first : second;
 }
 
-function merge_import() {
+function latest_changelog_read_date(local_date, imported_date) {
+    if (local_date === null || local_date === undefined) {
+        return imported_date ?? null;
+    }
+    if (imported_date === null || imported_date === undefined) {
+        return local_date;
+    }
+    return local_date >= imported_date ? local_date : imported_date;
+}
+
+function apply_import_plan() {
     const imported_state = _PENDING_IMPORT.state;
-    const imported_history = _PENDING_IMPORT.history;
     const imported_timestamp = Number(_PENDING_IMPORT.exported_at) || 0;
     const local_timestamp = current_backup_timestamp();
-    const imported_to_merged_ids = {};
 
     _IMPORT_MERGED_STATE = clone_object(STATE);
     _IMPORT_MERGED_HISTORY = clone_object(get_session_history());
     _IMPORT_CONFLICTS = [];
 
-    for (const imported_profile of Object.values(imported_state.profiles)) {
-        let target_id = find_merge_profile_id(
-            _IMPORT_MERGED_STATE.profiles, imported_profile);
+    const selected_plans = _IMPORT_PROFILE_PLANS.filter(
+        (plan) => plan.action !== "skip");
+    if (selected_plans.length === 0) {
+        cancel_import();
+        return;
+    }
+    for (const plan of selected_plans) {
+        const imported_profile = plan.imported;
+        let target_id = plan.target_id;
         if (target_id === null) {
             target_id = String(imported_profile.id);
             if (Object.prototype.hasOwnProperty.call(
@@ -2013,44 +2473,67 @@ function merge_import() {
             const added_profile = clone_object(imported_profile);
             added_profile.id = Number(target_id);
             _IMPORT_MERGED_STATE.profiles[target_id] = added_profile;
+        } else if (plan.action === "replace") {
+            const replacement = clone_object(imported_profile);
+            replacement.id = _IMPORT_MERGED_STATE.profiles[target_id].id;
+            _IMPORT_MERGED_STATE.profiles[target_id] = replacement;
         } else {
             const local_profile = _IMPORT_MERGED_STATE.profiles[target_id];
             const base_profile = clone_object(newer_profile(local_profile, imported_profile));
             base_profile.id = local_profile.id;
             _IMPORT_MERGED_STATE.profiles[target_id] = base_profile;
 
-            if (profile_settings_differ(local_profile, imported_profile)) {
+            const differing_fields = differing_settings(
+                local_profile, imported_profile, _PROFILE_SETTING_FIELDS);
+            if (differing_fields.length > 0) {
                 const local_settings_time =
-                    profile_settings_timestamp(local_profile, local_timestamp);
+                    profile_settings_timestamp(local_profile);
                 const imported_settings_time =
                     profile_settings_timestamp(imported_profile, imported_timestamp);
                 _IMPORT_CONFLICTS.push({
                     target_id: target_id,
                     local: clone_object(local_profile),
                     imported: clone_object(imported_profile),
+                    fields: differing_fields,
+                    kind: "profile",
+                    name: local_profile.name,
                     newer: imported_settings_time > local_settings_time
                         ? "imported" : "local",
                 });
             }
         }
-        imported_to_merged_ids[String(imported_profile.id)] = target_id;
-    }
 
-    for (const [imported_id, profile_history] of Object.entries(imported_history)) {
-        const target_id = imported_to_merged_ids[imported_id] || imported_id;
-        if (_IMPORT_MERGED_HISTORY[target_id] === undefined) {
-            _IMPORT_MERGED_HISTORY[target_id] = {};
+        const imported_profile_history =
+            _PENDING_IMPORT.history[plan.imported_id] || {};
+        if (plan.action === "replace") {
+            _IMPORT_MERGED_HISTORY[target_id] = clone_object(imported_profile_history);
+        } else {
+            if (_IMPORT_MERGED_HISTORY[target_id] === undefined) {
+                _IMPORT_MERGED_HISTORY[target_id] = {};
+            }
+            merge_profile_history(
+                _IMPORT_MERGED_HISTORY[target_id], imported_profile_history);
         }
-        merge_profile_history(_IMPORT_MERGED_HISTORY[target_id], profile_history);
     }
 
-    _IMPORT_MERGED_STATE.changelog_last_read_date = Math.max(
-        _IMPORT_MERGED_STATE.changelog_last_read_date || 0,
-        imported_state.changelog_last_read_date || 0) || null;
-    if (imported_timestamp > local_timestamp &&
-        imported_state.suppress_changelog_notifications !== undefined) {
-        _IMPORT_MERGED_STATE.suppress_changelog_notifications =
-            imported_state.suppress_changelog_notifications;
+    // Reading the changelog in either backup means it remains read. An import
+    // must never make a previously dismissed notification unread again.
+    _IMPORT_MERGED_STATE.changelog_last_read_date = latest_changelog_read_date(
+        _IMPORT_MERGED_STATE.changelog_last_read_date,
+        imported_state.changelog_last_read_date);
+
+    const global_fields = differing_settings(
+        STATE, imported_state, _GLOBAL_SETTING_FIELDS);
+    if (selected_plans.length > 0 && global_fields.length > 0) {
+        _IMPORT_CONFLICTS.push({
+            target_id: null,
+            local: clone_object(STATE),
+            imported: clone_object(imported_state),
+            fields: global_fields,
+            kind: "global",
+            name: "Global settings",
+            newer: imported_timestamp > local_timestamp ? "imported" : "local",
+        });
     }
 
     if (_IMPORT_CONFLICTS.length === 0) {
@@ -2065,9 +2548,6 @@ function merge_import() {
 }
 
 function setting_display_value(field, value) {
-    if (field === "icon") {
-        return String(value).replace(/^fa-/, "").replaceAll("-", " ");
-    }
     if (typeof value === "boolean") {
         return value ? "Yes" : "No";
     }
@@ -2079,7 +2559,12 @@ function populate_import_settings_conflict() {
     const grid = document.getElementById("import-settings-grid");
     grid.replaceChildren();
     document.getElementById("import-conflict-title").textContent =
-        "Settings for " + conflict.local.name;
+        "Merge conflicts found for " + conflict.name + " (" +
+        (_IMPORT_CONFLICT_INDEX + 1) + " of " + _IMPORT_CONFLICTS.length + " conflicts)";
+    document.getElementById("import-conflict-description").textContent =
+        conflict.kind === "global"
+            ? "Choose which value to keep for the app-wide setting."
+            : "Choose which value to keep for each setting that differs.";
 
     const local_age = conflict.newer === "local" ? "newer" : "older";
     const imported_age = conflict.newer === "imported" ? "newer" : "older";
@@ -2093,14 +2578,15 @@ function populate_import_settings_conflict() {
         grid.appendChild(element);
     }
 
-    const selected_side = _IMPORT_CHOICE_FOR_ALL === null
+    const selected_side = conflict.kind === "global" || _IMPORT_CHOICE_FOR_ALL === null
         ? conflict.newer
         : (_IMPORT_CHOICE_FOR_ALL === "newer"
             ? conflict.newer
             : (conflict.newer === "local" ? "imported" : "local"));
 
-    for (const [field, label] of _PROFILE_SETTING_FIELDS) {
+    for (const [field, label] of conflict.fields) {
         const label_element = document.createElement("div");
+        label_element.className = "import-setting-name";
         label_element.textContent = label;
         grid.appendChild(label_element);
 
@@ -2113,14 +2599,34 @@ function populate_import_settings_conflict() {
             radio.value = side;
             radio.checked = side === selected_side;
             value_label.appendChild(radio);
-            value_label.append(setting_display_value(field, conflict[side][field]));
+            const value_element = document.createElement("span");
+            value_element.className = "import-setting-value-text";
+            if (field === "icon") {
+                const icon = document.createElement("i");
+                icon.className = "fa fa-solid import-setting-icon " + conflict[side][field];
+                icon.setAttribute("aria-label", setting_display_value(
+                    field, conflict[side][field]));
+                value_element.appendChild(icon);
+            } else {
+                value_element.textContent = setting_display_value(
+                    field, conflict[side][field]);
+            }
+            value_label.appendChild(value_element);
             grid.appendChild(value_label);
         }
     }
 
+    const remaining_users = _IMPORT_CONFLICTS.slice(_IMPORT_CONFLICT_INDEX + 1)
+        .filter((remaining) => remaining.kind === "profile").length;
+    const apply_container = document.getElementById("apply-import-choice-to-all").closest("label");
+    apply_container.hidden = conflict.kind !== "profile" || remaining_users === 0;
+    document.getElementById("apply-import-choice-label").textContent =
+        "Apply choice to remaining " + remaining_users + " " +
+        (remaining_users === 1 ? "user" : "users");
+
     const next_button = document.getElementById("next-import-conflict-button");
     next_button.textContent = _IMPORT_CONFLICT_INDEX === _IMPORT_CONFLICTS.length - 1
-        ? "Finish import" : "Next user";
+        ? "Finish import" : "Next conflict";
 }
 
 function choose_all_import_settings(age) {
@@ -2133,29 +2639,35 @@ function choose_all_import_settings(age) {
         radio.checked = true;
     }
 
-    if (document.getElementById("apply-import-choice-to-all").checked) {
+    if (conflict.kind === "profile" &&
+        document.getElementById("apply-import-choice-to-all").checked) {
         _IMPORT_CHOICE_FOR_ALL = age;
     }
 }
 
 function save_import_settings_choice() {
     const conflict = _IMPORT_CONFLICTS[_IMPORT_CONFLICT_INDEX];
-    const merged_profile = _IMPORT_MERGED_STATE.profiles[conflict.target_id];
-    for (const [field] of _PROFILE_SETTING_FIELDS) {
+    const merge_target = conflict.kind === "global"
+        ? _IMPORT_MERGED_STATE
+        : _IMPORT_MERGED_STATE.profiles[conflict.target_id];
+    for (const [field] of conflict.fields) {
         const selected = document.querySelector(
             "input[name='import-setting-" + field + "']:checked").value;
-        merged_profile[field] = clone_object(conflict[selected][field]);
+        merge_target[field] = clone_object(conflict[selected][field]);
     }
-    merged_profile.settings_updated_time = Math.max(
-        profile_settings_timestamp(conflict.local),
-        profile_settings_timestamp(
-            conflict.imported, Number(_PENDING_IMPORT.exported_at) || 0));
+    if (conflict.kind === "profile") {
+        merge_target.settings_updated_time = Math.max(
+            profile_settings_timestamp(conflict.local),
+            profile_settings_timestamp(
+                conflict.imported, Number(_PENDING_IMPORT.exported_at) || 0));
+    }
 
     _IMPORT_CONFLICT_INDEX++;
     if (_IMPORT_CONFLICT_INDEX === _IMPORT_CONFLICTS.length) {
         install_imported_data(_IMPORT_MERGED_STATE, _IMPORT_MERGED_HISTORY);
         return;
     }
+    document.getElementById("apply-import-choice-to-all").checked = false;
     populate_import_settings_conflict();
 }
 


### PR DESCRIPTION
The existing backup easter egg could export local state, but there was no way to restore it. This adds a matching upload action with merge, replace and cancel options.\n\nMerges combine profiles and session history automatically. When the same profile has different settings, the import walks through those profiles one at a time and allows each setting to be selected independently. The export timestamp and per-profile settings timestamp make the all-from-newer and all-from-older shortcuts deterministic.