### PR TITLE
Increase statistics history height

### DIFF
--- a/_sass/_cim.scss
+++ b/_sass/_cim.scss
@@ -1030,8 +1030,8 @@ a.download-button.visible {
 // Stats container
 div.stats-history-container {
     width: max-content;
-    max-height: 40vh; // Fallback
-    max-height: 40dvh;
+    max-height: 80vh; // Fallback
+    max-height: 80dvh;
     max-width: 100vw; // Fallback
     max-width: 100dvw;
     overflow-y: auto;


### PR DESCRIPTION
At the moment, the statistics history modal is capped at 40% of the viewport height, so longer histories require scrolling even when there is plenty of vertical space available.

This raises the limit to 80%. The history remains scrollable when it is taller than the available space.