### PR TITLE
Add changelog entry for statistics history height

### DIFF
--- a/changelog.d/stats-history-height.md
+++ b/changelog.d/stats-history-height.md
@@ -1,0 +1,1 @@
+Made the statistics history popup taller so more sessions are visible at once.


### PR DESCRIPTION
## Summary

Add the changelog fragment that was omitted when the statistics history popup was made taller. This will include the change in the web preview and the next Android release notes.

## Test plan

- [x] `make html`

## Checklist

- [x] `make html` passes without errors
- [x] Changelog entry added to `changelog.d/`