### PR TITLE
Add opt-in Android release presubmit

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -100,6 +100,10 @@ jobs:
           (startsWith(github.ref, 'refs/tags/v') &&
            !contains(github.ref_name, '.dev')) || env.RELEASE_TEST == 'true'
         run: make test-fdroiddata
+        env:
+          # pull_request workflows check out an ephemeral merge commit which
+          # cannot be fetched by F-Droid's clean clone of the repository.
+          FDROID_GIT_COMMIT: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Enable KVM
         run: sudo chmod 666 /dev/kvm

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,8 +5,9 @@
 #   GitHub Release for the tag.
 # - Development tags: build a signed APK and upload it as an artifact.
 # - workflow_dispatch: build an unsigned debug APK.
-# - Pull requests touching the Android build: build an unsigned debug
-#   APK as a smoke test and upload it as a workflow artifact.
+# - Pull requests touching the Android build: build an unsigned debug APK.
+#   Applying the test-android-release label instead runs the signed stable
+#   release path without creating a GitHub Release.
 name: Android APK
 
 on:
@@ -16,6 +17,7 @@ on:
   workflow_dispatch:
 
   pull_request:
+    types: [opened, reopened, synchronize, labeled]
     paths:
       - "_data/theme.json"
       - "_config.yml"
@@ -51,6 +53,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TEST: >-
+        ${{ github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            contains(github.event.pull_request.labels.*.name, 'test-android-release') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -89,7 +96,9 @@ jobs:
         run: make test-android-reproducible
 
       - name: Test F-Droid build recipe
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '.dev')
+        if: >-
+          (startsWith(github.ref, 'refs/tags/v') &&
+           !contains(github.ref_name, '.dev')) || env.RELEASE_TEST == 'true'
         run: make test-fdroiddata
 
       - name: Enable KVM
@@ -100,10 +109,14 @@ jobs:
 
       # --- Pull requests and manual runs: unsigned debug APK ---
       - name: Build debug APK
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        if: >-
+          (github.event_name == 'pull_request' && env.RELEASE_TEST != 'true') ||
+          github.event_name == 'workflow_dispatch'
         run: cd android && ./gradlew assembleDebug
       - name: Upload debug APK
-        if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
+        if: >-
+          (github.event_name == 'pull_request' && env.RELEASE_TEST != 'true') ||
+          github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
           name: cim-debug-apk
@@ -111,7 +124,7 @@ jobs:
 
       # --- Tags: signed APK ---
       - name: Decode keystore
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || env.RELEASE_TEST == 'true'
         run: echo "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/cim-release.jks"
         env:
           KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
@@ -120,29 +133,33 @@ jobs:
       # Pinning only the signer leaves compilation on the current SDK while
       # allowing F-Droid to publish our verified, upstream-signed APK.
       - name: Install reproducible APK signer
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || env.RELEASE_TEST == 'true'
         uses: android-actions/setup-android@v4
         with:
           packages: 'build-tools;34.0.0'
 
-      - name: Compute version from tag
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Compute release version
+        if: startsWith(github.ref, 'refs/tags/v') || env.RELEASE_TEST == 'true'
         id: version
         run: |
-          NAME="${GITHUB_REF_NAME#v}"
+          if [[ $GITHUB_REF == refs/tags/v* ]]; then
+            NAME="${GITHUB_REF_NAME#v}"
+          else
+            NAME=$(node -p "require('./android-version.json').versionName")
+          fi
           CODE=$(./scripts/tag_android_version.sh --version-code "$NAME")
           echo "name=$NAME" >> "$GITHUB_OUTPUT"
           echo "code=$CODE" >> "$GITHUB_OUTPUT"
 
       - name: Build unsigned release APK
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || env.RELEASE_TEST == 'true'
         run: |
           cd android && ./gradlew assembleRelease \
             -PcimVersionName='${{ steps.version.outputs.name }}' \
             -PcimVersionCode='${{ steps.version.outputs.code }}'
 
       - name: Sign release APK
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || env.RELEASE_TEST == 'true'
         run: |
           SDK="${ANDROID_SDK_ROOT:-$ANDROID_HOME}"
           "$SDK/build-tools/34.0.0/apksigner" sign \
@@ -150,7 +167,7 @@ jobs:
             --ks-pass env:KEYSTORE_PASSWORD \
             --ks-key-alias "$KEY_ALIAS" \
             --key-pass env:KEY_PASSWORD \
-            --out "cim-${GITHUB_REF_NAME}.apk" \
+            --out "cim-v${{ steps.version.outputs.name }}.apk" \
             android/app/build/outputs/apk/release/app-release-unsigned.apk
         env:
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
@@ -158,8 +175,17 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Verify F-Droid reproducibility
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '.dev')
-        run: ./scripts/test_fdroiddata.sh verify "cim-${GITHUB_REF_NAME}.apk"
+        if: >-
+          (startsWith(github.ref, 'refs/tags/v') &&
+           !contains(github.ref_name, '.dev')) || env.RELEASE_TEST == 'true'
+        run: ./scripts/test_fdroiddata.sh verify "cim-v${{ steps.version.outputs.name }}.apk"
+
+      - name: Upload release-test APK
+        if: env.RELEASE_TEST == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cim-release-test-apk
+          path: cim-*.apk
 
       - name: Upload development APK artifact
         if: startsWith(github.ref, 'refs/tags/v') && contains(github.ref_name, '.dev')

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ test-fdroiddata-lint: test-fdroid-metadata
 
 .PHONY: test-fdroiddata
 test-fdroiddata: test-fdroid-metadata
-	./scripts/test_fdroiddata.sh build "$$(git rev-parse HEAD)"
+	./scripts/test_fdroiddata.sh build "$${FDROID_GIT_COMMIT:-$$(git rev-parse HEAD)}"
 
 .PHONY: test
 test: test-fdroid-metadata test-e2e

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## Android Version v2026.08.1
+
+### 2026-08-02
+
+- Made the statistics history popup taller so more sessions are visible at once.
+
 ## Android Version v2026.08.0
 
 ### 2026-06-06

--- a/android-version.json
+++ b/android-version.json
@@ -1,4 +1,4 @@
 {
-  "versionName": "2026.08.0",
-  "versionCode": 60800000
+  "versionName": "2026.08.1",
+  "versionCode": 60801000
 }

--- a/changelog.d/stats-history-height.md
+++ b/changelog.d/stats-history-height.md
@@ -1,1 +1,0 @@
-Made the statistics history popup taller so more sessions are visible at once.

--- a/docs/android.md
+++ b/docs/android.md
@@ -215,6 +215,12 @@ release appears after pushing the tag, check the corresponding `Android APK`
 workflow run. A failed prerequisite stops the job before it builds, signs, or
 publishes the APK.
 
+To exercise the stable release path before tagging, apply the
+`test-android-release` label to a same-repository pull request. The labeled run
+builds the F-Droid recipe, signs the release APK, verifies reproducibility, and
+uploads the signed APK as a workflow artifact. It deliberately does not create
+a GitHub Release. Subsequent pushes repeat the test while the label remains.
+
 Versions have the form `YYYY.MM.patch`. The script resets `patch` to `0` in a
 new month and otherwise increments the latest tag's patch number. Android's
 integer `versionCode` stores the year since 2020, followed by two digits for

--- a/fastlane/metadata/android/en-US/changelogs/60801000.txt
+++ b/fastlane/metadata/android/en-US/changelogs/60801000.txt
@@ -1,0 +1,1 @@
+- Made the statistics history popup taller so more sessions are visible at once.

--- a/fdroid/metadata/us.ganbar.cim.yml
+++ b/fdroid/metadata/us.ganbar.cim.yml
@@ -20,9 +20,9 @@ RepoType: git
 Repo: https://github.com/pganssle/cim.git
 
 Builds:
-  - versionName: 2026.08.0
-    versionCode: 60800000
-    commit: v2026.08.0
+  - versionName: 2026.08.1
+    versionCode: 60801000
+    commit: v2026.08.1
     sudo:
       - apt-get update
       - apt-get install -y build-essential bundler ruby-dev xz-utils
@@ -51,5 +51,5 @@ AutoUpdateMode: Version
 UpdateCheckMode: Tags ^v[0-9]{4}\.[0-9]{2}\.[0-9]+$
 UpdateCheckData:
   android-version.json|"versionCode":\s*([0-9]+)|android-version.json|"versionName":\s*"([^"]+)"
-CurrentVersion: 2026.08.0
-CurrentVersionCode: 60800000
+CurrentVersion: 2026.08.1
+CurrentVersionCode: 60801000

--- a/scripts/test_fdroiddata.sh
+++ b/scripts/test_fdroiddata.sh
@@ -74,6 +74,9 @@ case ${1:-lint} in
     build)
         [[ $# -le 2 ]] || { usage; exit 2; }
         readonly SOURCE_COMMIT=${2:-$(git rev-parse HEAD)}
+        if ! git cat-file -e "$SOURCE_COMMIT^{commit}" 2>/dev/null; then
+            git fetch --no-tags --depth=1 origin "$SOURCE_COMMIT"
+        fi
         sed -i "s/^    commit: .*/    commit: $SOURCE_COMMIT/" "$METADATA"
         source_date=$(git show -s --format=%cI "$SOURCE_COMMIT")
         git -C "$FDROIDDATA_DIR" add "metadata/$APP_ID.yml"

--- a/scripts/test_fdroiddata.sh
+++ b/scripts/test_fdroiddata.sh
@@ -62,7 +62,7 @@ run_fdroid() {
         -e GIT_CONFIG_KEY_0=safe.directory \
         -e GIT_CONFIG_VALUE_0=/repo \
         -e GIT_CONFIG_KEY_1=safe.directory \
-        -e 'GIT_CONFIG_VALUE_1=/repo/*' \
+        -e "GIT_CONFIG_VALUE_1=/repo/build/$APP_ID" \
         "$BUILD_IMAGE" python3 -m fdroidserver "$@"
 }
 
@@ -73,9 +73,15 @@ case ${1:-lint} in
         ;;
     build)
         [[ $# -le 2 ]] || { usage; exit 2; }
-        if [[ -n ${2:-} ]]; then
-            sed -i "s/^    commit: .*/    commit: $2/" "$METADATA"
-        fi
+        readonly SOURCE_COMMIT=${2:-$(git rev-parse HEAD)}
+        sed -i "s/^    commit: .*/    commit: $SOURCE_COMMIT/" "$METADATA"
+        source_date=$(git show -s --format=%cI "$SOURCE_COMMIT")
+        git -C "$FDROIDDATA_DIR" add "metadata/$APP_ID.yml"
+        GIT_AUTHOR_DATE=$source_date GIT_COMMITTER_DATE=$source_date \
+            git -C "$FDROIDDATA_DIR" \
+                -c user.name='CIM F-Droid test' \
+                -c user.email='test@example.com' \
+                commit --quiet -m "Test $APP_ID metadata"
         # The upstream APK does not exist until the release job completes.
         # Build it first, then compare it with the signed APK in `verify`.
         sed -i '/^Binaries:/d; /^AllowedAPKSigningKeys:/d' "$METADATA"
@@ -116,7 +122,7 @@ case ${1:-lint} in
             -e GIT_CONFIG_KEY_0=safe.directory \
             -e GIT_CONFIG_VALUE_0=/repo \
             -e GIT_CONFIG_KEY_1=safe.directory \
-            -e 'GIT_CONFIG_VALUE_1=/repo/*' \
+            -e "GIT_CONFIG_VALUE_1=/repo/build/$APP_ID" \
             "$BUILD_IMAGE" python3 -c \
             'import sys, tempfile; from fdroidserver import common; common.config = common.read_config(); tmp = tempfile.TemporaryDirectory(); result = common.verify_apks(sys.argv[1], sys.argv[2], tmp.name); print(result or "F-Droid APK matches the signed release APK"); raise SystemExit(bool(result))' \
             /signed.apk "/repo/unsigned/${APP_ID}_${VERSION_CODE}.apk"


### PR DESCRIPTION
The failures in the tagged Android builds happen in steps that ordinary pull requests skip, which means we currently cannot test a fix without creating another release tag.

Applying the `test-android-release` label to a same-repository pull request now runs the stable F-Droid build, signs the release APK, verifies reproducibility, and uploads the signed APK as an artifact. GitHub Release creation remains restricted to stable version tags.

Exercising the new path exposed two assumptions in the F-Droid test helper: the metadata commit had no deterministic timestamp fallback, and pull request workflows used an ephemeral merge commit which F-Droid could not fetch. The helper now dates temporary metadata from the source revision and fetches that revision when it is absent from a shallow checkout.

The complete release presubmit passed in [Android APK run 30775413285](https://github.com/pganssle/cim/actions/runs/30775413285). The run uploaded `cim-release-test-apk` and skipped GitHub Release creation as intended.