### PR TITLE
Handle Android releases without pending changelog entries

### DIFF
--- a/docs/android.md
+++ b/docs/android.md
@@ -210,6 +210,11 @@ signed APK and attaches it as `cim-vYYYY.MM.patch.apk` to a GitHub Release for
 the tag. Sideload it directly, or use Obtainium as described above to track
 the releases page.
 
+If there are no pending changelog entries, the script warns and asks for
+confirmation before proceeding. An empty release updates the version metadata
+and creates the tag, but does not add an empty section to `NEWS.md` or create
+an empty F-Droid changelog file.
+
 The tag workflow creates the GitHub Release; don't create one manually. If no
 release appears after pushing the tag, check the corresponding `Android APK`
 workflow run. A failed prerequisite stops the job before it builds, signs, or

--- a/e2e/changelog.spec.js
+++ b/e2e/changelog.spec.js
@@ -30,7 +30,11 @@ test("web changelog entries appear only when fragments are pending", async ({}, 
         await writeFile(join(worktree, "changelog.d", "README"), "Contributor instructions.");
         await writeFile(join(worktree, "NEWS.md"), released_news);
 
-        let result = run_changelog(worktree, "build", "2099-12-31");
+        let result = run_changelog(worktree, "pending");
+        expect(result.status, result.stderr || result.stdout).toBe(0);
+        expect(result.stdout.trim()).toBe("false");
+
+        result = run_changelog(worktree, "build", "2099-12-31");
         expect(result.status, result.stderr || result.stdout).toBe(0);
         await expect(readFile(join(worktree, "NEWS.md"), "utf8"))
             .resolves.toBe(released_news);
@@ -41,6 +45,10 @@ test("web changelog entries appear only when fragments are pending", async ({}, 
 
         await writeFile(join(worktree, "changelog.d", "first.md"), "Added the first change.");
         await writeFile(join(worktree, "changelog.d", "second.md"), "Fixed the second change.");
+        result = run_changelog(worktree, "pending");
+        expect(result.status, result.stderr || result.stdout).toBe(0);
+        expect(result.stdout.trim()).toBe("true");
+
         result = run_changelog(worktree, "build", "2099-12-31");
         expect(result.status, result.stderr || result.stdout).toBe(0);
 
@@ -87,6 +95,10 @@ ${released_news}`);
         expect(news).toContain("### 2099-12-01");
         expect(news.indexOf("Android Version v2099.12.3"))
             .toBeLessThan(news.indexOf("Android Version v2025.01.0"));
+
+        const pending = run_changelog(worktree, "pending");
+        expect(pending.status, pending.stderr || pending.stdout).toBe(0);
+        expect(pending.stdout.trim()).toBe("false");
 
         const fdroid = await readFile(join(worktree,
             "fastlane/metadata/android/en-US/changelogs/123456.txt"), "utf8");

--- a/e2e/changelog.spec.js
+++ b/e2e/changelog.spec.js
@@ -34,8 +34,10 @@ test("web changelog entries appear only when fragments are pending", async ({}, 
         expect(result.status, result.stderr || result.stdout).toBe(0);
         await expect(readFile(join(worktree, "NEWS.md"), "utf8"))
             .resolves.toBe(released_news);
-        await expect(readFile(join(worktree, "_includes/news.md"), "utf8"))
-            .resolves.toBe(released_news);
+        const released_build = await readFile(
+            join(worktree, "_includes/news.md"), "utf8");
+        expect(released_build).toBe(released_news);
+        expect(released_build).not.toContain("Web-only Preview");
 
         await writeFile(join(worktree, "changelog.d", "first.md"), "Added the first change.");
         await writeFile(join(worktree, "changelog.d", "second.md"), "Fixed the second change.");

--- a/e2e/modals.spec.js
+++ b/e2e/modals.spec.js
@@ -34,15 +34,13 @@ test.describe("Informational modal", () => {
             .toHaveText("third-party notices");
         await expect(page.locator("#i-infobox")).not.toContainText("early alpha");
         await expect(page.locator("#changelog-section > h2")).toHaveText("What's New");
-        await expect(page.locator("#changelog-section .changelog-entries > h2").first())
-            .toHaveText("Web-only Preview");
         const newest_date = await page.locator(
             "#changelog-section .changelog-entries > h3").first().textContent();
         expect(newest_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
         await expect(page.locator("#i-infobox-trigger-container"))
             .toHaveAttribute("data-newest-date", newest_date);
-        await expect(page.locator("#changelog-section .changelog-entries > h2").nth(1))
-            .toHaveText("Android Version v2026.08.0");
+        await expect(page.locator("#changelog-section .changelog-entries > h2").first())
+            .toBeVisible();
 
         const changelog = page.locator(".changelog-container");
         await expect(changelog).toContainText("What's New");

--- a/scripts/tag_android_version.sh
+++ b/scripts/tag_android_version.sh
@@ -119,6 +119,23 @@ next_version() {
     echo "$name"
 }
 
+confirm_empty_release() {
+    local version=$1
+    local response
+    echo "warning: there are no changelog entries to include in v$version" >&2
+    printf 'Create the release anyway? [y/N] ' >&2
+    if ! IFS= read -r response; then
+        response=
+    fi
+    case $response in
+        y|Y) return 0 ;;
+        *)
+            echo "Aborted v$version" >&2
+            return 1
+            ;;
+    esac
+}
+
 create_tag() {
     local dev=$1
     if [[ -n $(git status --porcelain) ]]; then
@@ -132,12 +149,28 @@ create_tag() {
     code=$(version_code "$version")
 
     if [[ $dev == false ]]; then
+        local allow_empty=()
+        local pending
+        pending=$(node scripts/update_changelog.mjs pending)
+        case $pending in
+            true) ;;
+            false)
+                confirm_empty_release "$version" || return 1
+                allow_empty=(--allow-empty)
+                ;;
+            *)
+                echo "error: could not determine whether changelog entries are pending" >&2
+                return 1
+                ;;
+        esac
+
         node scripts/update_changelog.mjs web "$(date +%F)"
-        node scripts/update_changelog.mjs android "$version" "$code"
+        node scripts/update_changelog.mjs android "$version" "$code" \
+            "${allow_empty[@]}"
         node scripts/update_android_version.mjs "$version" "$code"
         git add -A -- NEWS.md changelog.d android-version.json \
             fdroid/metadata/us.ganbar.cim.yml \
-            "fastlane/metadata/android/en-US/changelogs/$code.txt"
+            fastlane/metadata/android/en-US/changelogs
         if ! git diff --cached --quiet; then
             git commit -m "Prepare v$version"
         fi

--- a/scripts/update_changelog.mjs
+++ b/scripts/update_changelog.mjs
@@ -47,6 +47,16 @@ async function fragment_files() {
         .map((entry) => join(FRAGMENTS_DIRECTORY, entry));
 }
 
+async function has_pending_entries() {
+    if ((await fragment_files()).length !== 0) {
+        return true;
+    }
+
+    const news = await readFile(NEWS_PATH, "utf8");
+    const { preview } = split_preview(news);
+    return preview?.split("\n").some((line) => line.startsWith("- ")) ?? false;
+}
+
 function format_fragment(fragment, path) {
     const text = fragment.trim();
     if (!text) {
@@ -133,7 +143,7 @@ function fdroid_changelog(preview) {
     return `${included.join("\n")}\n`;
 }
 
-async function release_android(version, version_code) {
+async function release_android(version, version_code, allow_empty) {
     if (!/^\d{4}\.\d{2}\.\d+$/.test(version ?? "") ||
             !/^\d+$/.test(version_code ?? "")) {
         throw new Error(
@@ -143,6 +153,9 @@ async function release_android(version, version_code) {
     const news = await readFile(NEWS_PATH, "utf8");
     const { preview, released } = split_preview(news);
     if (!preview) {
+        if (allow_empty) {
+            return;
+        }
         throw new Error("There are no Web-only Preview entries to release");
     }
 
@@ -161,15 +174,19 @@ async function release_android(version, version_code) {
 
 async function main() {
     const [command, ...args] = process.argv.slice(2);
-    if (command === "web" && args.length === 1) {
+    if (command === "pending" && args.length === 0) {
+        console.log(await has_pending_entries() ? "true" : "false");
+    } else if (command === "web" && args.length === 1) {
         await release_web(args[0]);
     } else if (command === "build" && args.length === 1) {
         await build_web(args[0]);
-    } else if (command === "android" && args.length === 2) {
-        await release_android(args[0], args[1]);
+    } else if (command === "android" &&
+            (args.length === 2 ||
+             (args.length === 3 && args[2] === "--allow-empty"))) {
+        await release_android(args[0], args[1], args[2] === "--allow-empty");
     } else {
         throw new Error(
-            "usage: update_changelog.mjs {build YYYY-MM-DD | web YYYY-MM-DD | android YYYY.MM.PATCH VERSION_CODE}");
+            "usage: update_changelog.mjs {pending | build YYYY-MM-DD | web YYYY-MM-DD | android YYYY.MM.PATCH VERSION_CODE [--allow-empty]}");
     }
 }
 

--- a/tests/test_fdroid_metadata.mjs
+++ b/tests/test_fdroid_metadata.mjs
@@ -51,11 +51,13 @@ for (const file of [
   "fastlane/metadata/android/en-US/images/tenInchScreenshots/02-single-note-follow-on.png",
   "fastlane/metadata/android/en-US/images/tenInchScreenshots/03-music-trainer.png",
   "fastlane/metadata/android/en-US/images/tenInchScreenshots/04-statistics.png",
-  changelog,
 ]) {
   assert(fs.statSync(file).size > 0, `${file} is missing or empty`);
 }
-assert(fs.readFileSync(changelog, "utf8").length <= 500,
-  `${changelog} exceeds F-Droid's 500-character limit`);
+if (fs.existsSync(changelog)) {
+  assert(fs.statSync(changelog).size > 0, `${changelog} is empty`);
+  assert(fs.readFileSync(changelog, "utf8").length <= 500,
+    `${changelog} exceeds F-Droid's 500-character limit`);
+}
 
 console.log("F-Droid metadata is consistent with android-version.json");

--- a/tests/test_tag_android_version.sh
+++ b/tests/test_tag_android_version.sh
@@ -112,6 +112,35 @@ if grep -q 'Web-only Preview' NEWS.md; then
     exit 1
 fi
 grep -q "^## Android Version v$year.$month.4$" NEWS.md
+
+released_head=$(git rev-parse HEAD)
+released_news=$(cat NEWS.md)
+if empty_release_output=$(printf '\n' | create_tag false 2>&1); then
+    echo 'error: empty release unexpectedly proceeded without confirmation' >&2
+    exit 1
+fi
+grep -q "warning: there are no changelog entries to include in v$year.$month.5" \
+    <<< "$empty_release_output"
+grep -q 'Create the release anyway? \[y/N\]' <<< "$empty_release_output"
+assert_equal "$(git rev-parse HEAD)" "$released_head"
+assert_equal "$(node -p "require('./android-version.json').versionName")" \
+    "$year.$month.4"
+if git tag --list "v$year.$month.5" | grep -q .; then
+    echo 'error: declining an empty release still created its tag' >&2
+    exit 1
+fi
+
+printf 'y\n' | create_tag false > /dev/null 2>&1
+assert_equal "$(git tag --points-at HEAD)" "v$year.$month.5"
+assert_equal "$(node -p "require('./android-version.json').versionName")" \
+    "$year.$month.5"
+assert_equal "$(git log -1 --format=%s)" "Prepare v$year.$month.5"
+assert_equal "$(cat NEWS.md)" "$released_news"
+empty_code=$(version_code "$year.$month.5")
+if [[ -e fastlane/metadata/android/en-US/changelogs/$empty_code.txt ]]; then
+    echo 'error: empty release created an F-Droid changelog' >&2
+    exit 1
+fi
 popd > /dev/null
 
 echo 'Version tagging tests passed'


### PR DESCRIPTION
The modal test assumed that every build would have a `Web-only Preview` section. That is not true immediately after preparing an Android release, so the test failed on `main` even though the rendered changelog was correct. This keeps the modal test independent of the current fragment state and explicitly checks in the controlled changelog fixture that no preview is generated when there are no fragments.

The Android tag script also no longer treats an empty changelog as an unconditional error. It warns and prompts with a default of `N` before changing anything. If confirmed with `y`, it updates the version metadata and creates the tag without adding an empty NEWS section or F-Droid changelog file.

Tests:

- `./tests/test_tag_android_version.sh`
- `make test`

The full run passed 100 Playwright tests with 2 expected skips, as well as the F-Droid metadata check and Android emulator smoke test.