### PR TITLE
Keep Android button navigation visible

### DIFF
--- a/android-tests/java/us/ganbar/cim/MainActivityTest.java
+++ b/android-tests/java/us/ganbar/cim/MainActivityTest.java
@@ -7,7 +7,14 @@ import static androidx.test.espresso.web.webdriver.DriverAtoms.findElement;
 import static androidx.test.espresso.web.webdriver.DriverAtoms.getText;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.test.espresso.web.webdriver.Locator;
 import androidx.test.ext.junit.rules.ActivityScenarioRule;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
@@ -31,5 +38,42 @@ public class MainActivityTest {
                 .check(webMatches(getCurrentUrl(), startsWith("https://localhost")))
                 .withElement(findElement(Locator.ID, "play-button"))
                 .check(webMatches(getText(), notNullValue(String.class)));
+    }
+
+    @Test
+    public void systemBarsMatchNavigationMode() {
+        activityRule.getScenario().onActivity(
+                activity -> {
+                    WindowInsetsCompat windowInsets =
+                            ViewCompat.getRootWindowInsets(activity.getWindow().getDecorView());
+
+                    assertNotNull(windowInsets);
+                    assertFalse(windowInsets.isVisible(WindowInsetsCompat.Type.statusBars()));
+                    assertEquals(
+                            MainActivity.shouldHideNavigationBar(windowInsets),
+                            !windowInsets.isVisible(WindowInsetsCompat.Type.navigationBars()));
+                });
+    }
+
+    @Test
+    public void gestureNavigationBarShouldBeHidden() {
+        WindowInsetsCompat windowInsets =
+                new WindowInsetsCompat.Builder()
+                        .setInsetsIgnoringVisibility(
+                                WindowInsetsCompat.Type.tappableElement(), Insets.NONE)
+                        .build();
+
+        assertTrue(MainActivity.shouldHideNavigationBar(windowInsets));
+    }
+
+    @Test
+    public void buttonNavigationBarShouldRemainVisible() {
+        WindowInsetsCompat windowInsets =
+                new WindowInsetsCompat.Builder()
+                        .setInsetsIgnoringVisibility(
+                                WindowInsetsCompat.Type.tappableElement(), Insets.of(0, 0, 0, 48))
+                        .build();
+
+        assertFalse(MainActivity.shouldHideNavigationBar(windowInsets));
     }
 }

--- a/changelog.d/android-system-bars.md
+++ b/changelog.d/android-system-bars.md
@@ -1,0 +1,1 @@
+On Android, the app now hides the status bar while keeping three-button navigation controls visible.

--- a/patches/android/MainActivity-java.patch
+++ b/patches/android/MainActivity-java.patch
@@ -1,10 +1,16 @@
 --- a/app/src/main/java/us/ganbar/cim/MainActivity.java
 +++ b/app/src/main/java/us/ganbar/cim/MainActivity.java
-@@ -1,5 +1,16 @@
+@@ -1,5 +1,50 @@
  package us.ganbar.cim;
  
 +import android.os.Bundle;
 +import android.view.WindowManager;
++
++import androidx.core.graphics.Insets;
++import androidx.core.view.ViewCompat;
++import androidx.core.view.WindowCompat;
++import androidx.core.view.WindowInsetsCompat;
++import androidx.core.view.WindowInsetsControllerCompat;
 +
  import com.getcapacitor.BridgeActivity;
  
@@ -16,5 +22,33 @@
 +        // Training sessions are listen-only for long stretches; don't let the
 +        // screen turn off mid-exercise.
 +        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
++
++        configureSystemBars();
++    }
++
++    static boolean shouldHideNavigationBar(WindowInsetsCompat windowInsets) {
++        // A nonzero tappable bottom inset identifies three-button navigation.
++        Insets tappableInsets =
++                windowInsets.getInsetsIgnoringVisibility(
++                        WindowInsetsCompat.Type.tappableElement());
++        return tappableInsets.bottom == 0;
++    }
++
++    private void configureSystemBars() {
++        WindowInsetsControllerCompat controller =
++                WindowCompat.getInsetsController(getWindow(), getWindow().getDecorView());
++
++        ViewCompat.setOnApplyWindowInsetsListener(
++                getWindow().getDecorView(),
++                (view, windowInsets) -> {
++                    controller.hide(WindowInsetsCompat.Type.statusBars());
++                    if (shouldHideNavigationBar(windowInsets)) {
++                        controller.hide(WindowInsetsCompat.Type.navigationBars());
++                    } else {
++                        controller.show(WindowInsetsCompat.Type.navigationBars());
++                    }
++                    return windowInsets;
++                });
++        ViewCompat.requestApplyInsets(getWindow().getDecorView());
 +    }
 +}


### PR DESCRIPTION
The Android app currently relies on a single fullscreen treatment regardless of the system navigation mode. This can cause three-button navigation controls to appear transiently over the app.

Hide the status bar in all cases, then use the tappable-element inset to distinguish the navigation modes. Gesture navigation remains immersive, including hiding its handle, while three-button navigation remains visible. The insets listener reapplies the choice if the window configuration changes.

The Android instrumentation tests cover the system-bar state on the managed emulator as well as synthetic gesture- and button-navigation insets.

Tests:

- `make test`